### PR TITLE
Update Account Schema

### DIFF
--- a/.env
+++ b/.env
@@ -17,5 +17,5 @@ SESSION_SECRET=O Rui foi membro do IEEE.
 # Specifies the port in which the app will be exposed
 PORT=8087
 
-# Admin Token - OVERRIDE IN PRODUCTION
-ADMIN_TOKEN=password123
+# GOD Token - OVERRIDE IN PRODUCTION
+GOD_TOKEN=password123

--- a/.env.test
+++ b/.env.test
@@ -9,5 +9,5 @@ PORT=8097
 # If tests depend on the secret, let's at least make it consistent!
 SESSION_SECRET=constant_testing_s3cr3t
 
-# So that the api calls can use a hardcoded admin token
-ADMIN_TOKEN=testing_is_cool73
+# So that the api calls can use a hardcoded god token
+GOD_TOKEN=testing_is_cool73

--- a/package-lock.json
+++ b/package-lock.json
@@ -1306,9 +1306,9 @@
       }
     },
     "commander": {
-      "version": "2.20.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.1.tgz",
-      "integrity": "sha512-cCuLsMhJeWQ/ZpsFTbE765kvVfoeSddc4nU3up4fV+fDBcfUXnbITJ+JzhkdjzOqhURjZgujxaioam4RM9yGUg==",
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "dev": true,
       "optional": true
     },
@@ -3090,9 +3090,9 @@
       "dev": true
     },
     "handlebars": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.4.0.tgz",
-      "integrity": "sha512-xkRtOt3/3DzTKMOt3xahj2M/EqNhY988T+imYSlMgs5fVhLN2fmKVVj0LtEGmb+3UUYV5Qmm1052Mm3dIQxOvw==",
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.3.tgz",
+      "integrity": "sha512-3yPecJoJHK/4c6aZhSvxOyG4vJKDshV36VHp0iVCDVh7o9w2vwi3NSnL2MMPj3YdduqaBcu7cGbggJQM0br9xA==",
       "dev": true,
       "requires": {
         "neo-async": "^2.6.0",
@@ -6616,13 +6616,13 @@
       }
     },
     "uglify-js": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.0.tgz",
-      "integrity": "sha512-W+jrUHJr3DXKhrsS7NUVxn3zqMOFn0hL/Ei6v0anCIMoKC93TjcflTagwIHLW7SfMFfiQuktQyFVCFHGUE0+yg==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.7.0.tgz",
+      "integrity": "sha512-PC/ee458NEMITe1OufAjal65i6lB58R1HWMRcxwvdz1UopW0DYqlRL3xdu3IcTvTXsB02CRHykidkTRL+A3hQA==",
       "dev": true,
       "optional": true,
       "requires": {
-        "commander": "~2.20.0",
+        "commander": "~2.20.3",
         "source-map": "~0.6.1"
       },
       "dependencies": {

--- a/src/api/middleware/auth.js
+++ b/src/api/middleware/auth.js
@@ -24,7 +24,19 @@ const isGod = (req, res, next) => {
     return next();
 };
 
+const isAdmin = (req, res, next) => {
+    if (!req.user.isAdmin) {
+        return res.status(401).json({
+            reason: "The user is not an admin",
+            error_code: ErrorTypes.FORBIDDEN,
+        });
+    }
+
+    return next();
+};
+
 module.exports = {
     authRequired,
     isGod,
+    isAdmin,
 };

--- a/src/api/middleware/auth.js
+++ b/src/api/middleware/auth.js
@@ -12,11 +12,11 @@ const authRequired = (req, res, next) => {
     });
 };
 
-// Eventually should be done via a session in an admin account, but at least this will work for now, before a permission system is added
-const isAdmin = (req, res, next) => {
-    if (req.body.admin_token !== config.admin_token) {
+// Eventually should be done via a session in an god account, but at least this will work for now, before a permission system is added
+const isGod = (req, res, next) => {
+    if (req.body.god_token !== config.god_token) {
         return res.status(401).json({
-            reason: "Invalid admin token",
+            reason: "Invalid god token",
             error_code: ErrorTypes.FORBIDDEN,
         });
     }
@@ -26,5 +26,5 @@ const isAdmin = (req, res, next) => {
 
 module.exports = {
     authRequired,
-    isAdmin,
+    isGod,
 };

--- a/src/api/middleware/company.js
+++ b/src/api/middleware/company.js
@@ -1,9 +1,9 @@
 const { ErrorTypes } = require("./errorHandler");
 
-const belongsToCompany = (company_id) =>  (req, res, next) => {
-    if (!req.user.company ===  company_id) {
+const isCompanyRep = (req, res, next) => {
+    if (!req.user.company) {
         return res.status(401).json({
-            reason: "The user does not have access to the company",
+            reason: "The user is not a company representative",
             error_code: ErrorTypes.FORBIDDEN,
         });
     }
@@ -12,4 +12,4 @@ const belongsToCompany = (company_id) =>  (req, res, next) => {
 };
 
 
-module.exports = { belongsToCompany };
+module.exports = { isCompanyRep };

--- a/src/api/middleware/company.js
+++ b/src/api/middleware/company.js
@@ -1,0 +1,15 @@
+const { ErrorTypes } = require("./errorHandler");
+
+const belongsToCompany = (company_id) =>  (req, res, next) => {
+    if (!req.user.company ===  company_id) {
+        return res.status(401).json({
+            reason: "The user does not have access to the company",
+            error_code: ErrorTypes.FORBIDDEN,
+        });
+    }
+
+    return next();
+};
+
+
+module.exports = { belongsToCompany };

--- a/src/api/middleware/validators/auth.js
+++ b/src/api/middleware/validators/auth.js
@@ -3,19 +3,20 @@ const { body } = require("express-validator");
 const { useExpressValidators } = require("../errorHandler");
 const Account = require("../../../models/Account");
 
-const checkDuplicateUsername = async (username) => {
-    const acc = await Account.findOne({ username }).exec();
+const checkDuplicateEmail = async (email) => {
+    const acc = await Account.findOne({ email }).exec();
     if (acc) {
-        throw new Error("Username already exists");
+        throw new Error("Email already exists");
     }
 };
 
 const register = useExpressValidators([
-    body("username", "Invalid username")
-        .exists().withMessage("Username is required").bail()
-        .isString().withMessage("Username must be a String")
+    body("email", "Invalid email")
+        .exists().withMessage("Email is required").bail()
+        .isString().withMessage("Email must be a String")
+        .isEmail().withMessage("Email must be valid")
         .bail()
-        .custom(checkDuplicateUsername)
+        .custom(checkDuplicateEmail)
         .trim(),
 
     body("password", "Invalid password")

--- a/src/api/middleware/validators/auth.js
+++ b/src/api/middleware/validators/auth.js
@@ -13,8 +13,7 @@ const checkDuplicatedEmail = async (email) => {
 const register = useExpressValidators([
     body("email", "Invalid email")
         .exists().withMessage("Email is required").bail()
-        .isString().withMessage("Email must be a String")
-        .isEmail().withMessage("Email must be valid")
+        .normalizeEmail().isEmail().withMessage("Email must be valid")
         .bail()
         .custom(checkDuplicatedEmail)
         .trim(),
@@ -26,4 +25,15 @@ const register = useExpressValidators([
         .matches(/\d/).withMessage("Password must contain a number"),
 ]);
 
-module.exports = { register };
+const login =  useExpressValidators([
+    body("email", "Invalid email")
+        .exists().withMessage("Email is required").bail()
+        .normalizeEmail().isEmail().withMessage("Email must be valid")
+        .trim(),
+
+    body("password", "Invalid password")
+        .exists().withMessage("Password is required").bail()
+        .isString().withMessage("Password must be a String"),
+]);
+
+module.exports = { register, login };

--- a/src/api/middleware/validators/auth.js
+++ b/src/api/middleware/validators/auth.js
@@ -3,7 +3,7 @@ const { body } = require("express-validator");
 const { useExpressValidators } = require("../errorHandler");
 const Account = require("../../../models/Account");
 
-const checkDuplicateEmail = async (email) => {
+const checkDuplicatedEmail = async (email) => {
     const acc = await Account.findOne({ email }).exec();
     if (acc) {
         throw new Error("Email already exists");
@@ -16,7 +16,7 @@ const register = useExpressValidators([
         .isString().withMessage("Email must be a String")
         .isEmail().withMessage("Email must be valid")
         .bail()
-        .custom(checkDuplicateEmail)
+        .custom(checkDuplicatedEmail)
         .trim(),
 
     body("password", "Invalid password")

--- a/src/api/middleware/validators/auth.js
+++ b/src/api/middleware/validators/auth.js
@@ -7,7 +7,7 @@ const Account = require("../../../models/Account");
 const checkDuplicatedEmail = async (email) => {
     const acc = await Account.findOne({ email }).exec();
     if (acc) {
-        throw new Error("Email already exists");
+        throw new Error(ValidationReasons.ALREADY_EXISTS("email"));
     }
 };
 

--- a/src/api/middleware/validators/auth.js
+++ b/src/api/middleware/validators/auth.js
@@ -1,6 +1,7 @@
 const { body } = require("express-validator");
 
 const { useExpressValidators } = require("../errorHandler");
+const ValidationReasons = require("./validationReasons");
 const Account = require("../../../models/Account");
 
 const checkDuplicatedEmail = async (email) => {
@@ -11,29 +12,29 @@ const checkDuplicatedEmail = async (email) => {
 };
 
 const register = useExpressValidators([
-    body("email", "Invalid email")
-        .exists().withMessage("Email is required").bail()
-        .normalizeEmail().isEmail().withMessage("Email must be valid")
+    body("email", ValidationReasons.DEFAULT)
+        .exists().withMessage(ValidationReasons.REQUIRED).bail()
+        .normalizeEmail().isEmail().withMessage(ValidationReasons.EMAIL)
         .bail()
         .custom(checkDuplicatedEmail)
         .trim(),
 
-    body("password", "Invalid password")
-        .exists().withMessage("Password is required").bail()
-        .isString().withMessage("Password must be a String")
-        .isLength({ min: 8 }).withMessage("Password must have at least 8 characters")
-        .matches(/\d/).withMessage("Password must contain a number"),
+    body("password", ValidationReasons.DEFAULT)
+        .exists().withMessage(ValidationReasons.REQUIRED).bail()
+        .isString().withMessage(ValidationReasons.STRING)
+        .isLength({ min: 8 }).withMessage(ValidationReasons.TOO_SHORT(8))
+        .matches(/\d/).withMessage(ValidationReasons.HAVE_NUMBER),
 ]);
 
 const login =  useExpressValidators([
-    body("email", "Invalid email")
-        .exists().withMessage("Email is required").bail()
-        .normalizeEmail().isEmail().withMessage("Email must be valid")
+    body("email", ValidationReasons.DEFAULT)
+        .exists().withMessage(ValidationReasons.REQUIRED).bail()
+        .normalizeEmail().isEmail().withMessage(ValidationReasons.EMAIL)
         .trim(),
 
-    body("password", "Invalid password")
-        .exists().withMessage("Password is required").bail()
-        .isString().withMessage("Password must be a String"),
+    body("password", ValidationReasons.DEFAULT)
+        .exists().withMessage(ValidationReasons.REQUIRED).bail()
+        .isString().withMessage(ValidationReasons.STRING),
 ]);
 
 module.exports = { register, login };

--- a/src/api/middleware/validators/validationReasons.js
+++ b/src/api/middleware/validators/validationReasons.js
@@ -11,6 +11,7 @@ const ValidationReasons = Object.freeze({
     ARRAY_SIZE: (min, max) => `size-must-be-between:[${min},${max}]`,
     EMAIL: "must-be-a-valid-email",
     HAVE_NUMBER: "must-contain-number",
+    ALREADY_EXISTS: (variable) => `${variable}-already-exists`,
 });
 
 module.exports = ValidationReasons;

--- a/src/api/middleware/validators/validationReasons.js
+++ b/src/api/middleware/validators/validationReasons.js
@@ -9,6 +9,8 @@ const ValidationReasons = Object.freeze({
     BOOLEAN: "must-be-boolean",
     IN_ARRAY: (vals) => `must-be-in:[${vals}]`,
     ARRAY_SIZE: (min, max) => `size-must-be-between:[${min},${max}]`,
+    EMAIL: "must-be-a-valid-email",
+    HAVE_NUMBER: "must-contain-number",
 });
 
 module.exports = ValidationReasons;

--- a/src/api/routes/auth.js
+++ b/src/api/routes/auth.js
@@ -23,7 +23,7 @@ module.exports = (app) => {
     });
 
     // Login endpoint
-    router.post("/login", passport.authenticate("local"), (req, res) => res.status(200).json({}));
+    router.post("/login", validators.login, passport.authenticate("local"), (req, res) => res.status(200).json({}));
 
     // Logout endpoint
     router.delete("/login", authRequired, (req, res) => {

--- a/src/api/routes/auth.js
+++ b/src/api/routes/auth.js
@@ -17,7 +17,7 @@ module.exports = (app) => {
         return res.status(200).json({
             data: {
                 _id: userInfo._id,
-                username: userInfo.username,
+                email: userInfo.email,
             },
         });
     });
@@ -33,11 +33,11 @@ module.exports = (app) => {
 
     // Register endpoint
     router.post("/register", validators.register, async (req, res, next) => {
-        const { username, password } = req.body;
+        const { email, password } = req.body;
 
         // Inserting user into db and replying with success or not
         try {
-            const data = await (new AuthService()).register(username, password);
+            const data = await (new AuthService()).register(email, password);
 
             return res.status(200).json({
                 data,

--- a/src/api/routes/auth.js
+++ b/src/api/routes/auth.js
@@ -1,7 +1,7 @@
 const { Router } = require("express");
 const passport = require("passport");
 
-const { authRequired } = require("../middleware/auth");
+const { authRequired, isGod } = require("../middleware/auth");
 const validators = require("../middleware/validators/auth");
 const AuthService = require("../../services/auth");
 
@@ -32,7 +32,7 @@ module.exports = (app) => {
     });
 
     // Register endpoint
-    router.post("/register", validators.register, async (req, res, next) => {
+    router.post("/register", isGod, validators.register, async (req, res, next) => {
         const { email, password } = req.body;
 
         // Inserting user into db and replying with success or not

--- a/src/api/routes/offer.js
+++ b/src/api/routes/offer.js
@@ -26,7 +26,7 @@ module.exports = (app) => {
     /**
      * Creates a new Offer
      */
-    router.post("/", authMiddleware.isAdmin, validators.create, async (req, res) => {
+    router.post("/", authMiddleware.isGod, validators.create, async (req, res) => {
         try {
             // This is safe since the service is destructuring the passed object and the fields have been validated
             const offer = await (new OfferService()).create(req.body);

--- a/src/config/env.js
+++ b/src/config/env.js
@@ -13,6 +13,6 @@ module.exports = Object.freeze({
 
     port: process.env.PORT,
 
-    // Admin token
-    admin_token: process.env.ADMIN_TOKEN,
+    // God token
+    god_token: process.env.GOD_TOKEN,
 });

--- a/src/config/passport.js
+++ b/src/config/passport.js
@@ -4,21 +4,24 @@ const LocalStrategy = require("passport-local").Strategy;
 const Account = require("../models/Account");
 
 // Passport configuration
-passport.use(new LocalStrategy(
-    (username, password, done) => {
-        Account.findOne({ username: username }, (err, user) => {
-            if (err) {
-                return done(err);
-            }
-            if (!user) {
-                return done(null, false, { message: "Incorrect username." });
-            }
-            if (!user.validatePassword(password)) {
-                return done(null, false, { message: "Incorrect password." });
-            }
-            return done(null, user);
-        });
-    }
+passport.use(new LocalStrategy({
+    usernameField: "email",
+    passwordField: "password",
+},
+(email, password, done) => {
+    Account.findOne({ email: email }, (err, user) => {
+        if (err) {
+            return done(err);
+        }
+        if (!user) {
+            return done(null, false, { message: "Incorrect email." });
+        }
+        if (!user.validatePassword(password)) {
+            return done(null, false, { message: "Incorrect password." });
+        }
+        return done(null, user);
+    });
+}
 ));
 
 passport.serializeUser(function(user, done) {

--- a/src/config/passport.js
+++ b/src/config/passport.js
@@ -9,7 +9,7 @@ passport.use(new LocalStrategy({
     passwordField: "password",
 },
 (email, password, done) => {
-    Account.findOne({ email: email }, (err, user) => {
+    Account.findOne({ email }, (err, user) => {
         if (err) {
             return done(err);
         }

--- a/src/config/passport.js
+++ b/src/config/passport.js
@@ -13,11 +13,8 @@ passport.use(new LocalStrategy({
         if (err) {
             return done(err);
         }
-        if (!user) {
-            return done(null, false, { message: "Incorrect email." });
-        }
-        if (!user.validatePassword(password)) {
-            return done(null, false, { message: "Incorrect password." });
+        if (!user || !user.validatePassword(password)) {
+            return done(null, false, { message: "Incorrect email or password." });
         }
         return done(null, user);
     });

--- a/src/models/Account.js
+++ b/src/models/Account.js
@@ -20,7 +20,7 @@ const AccountSchema = new Schema({
             validator: function(isAdmin) {
                 return isAdmin && !this.company;
             },
-            message: "A user can not be an admin and a company representative",
+            message: "A user cannot be an admin and a company representative",
         },
     },
     company: {
@@ -32,7 +32,7 @@ const AccountSchema = new Schema({
             validator: function(companyRef) {
                 return !!companyRef && !this.isAdmin;
             },
-            message: "A user can not be an admin and a company representative",
+            message: "A user cannot be an admin and a company representative",
 
         },
     },

--- a/src/models/Account.js
+++ b/src/models/Account.js
@@ -3,7 +3,13 @@ const bcrypt = require("bcrypt");
 const { Schema } = mongoose;
 
 const AccountSchema = new Schema({
-    username: { type: String, unique: true, maxlength: 20, minlength: 3, required: true },
+    email: {
+        type: String,
+        trim: true,
+        lowercase: true,
+        unique: true,
+        required: "Email address is required",
+    },
     password: { type: String, required: true },
 });
 

--- a/src/models/Account.js
+++ b/src/models/Account.js
@@ -15,7 +15,7 @@ const AccountSchema = new Schema({
         type: Boolean,
         validate: {
             validator: function(isAdmin) {
-                return isAdmin && !this.company;
+                return !isAdmin && !!this.company;
             },
             message: "A user can not be an admin and a company representative",
         },
@@ -24,6 +24,10 @@ const AccountSchema = new Schema({
         type: Schema.Types.ObjectId, ref: "Company",
         validate: {
             validator: function(companyRef) {
+                console.log(companyRef);
+                console.log(this.isAdmin);
+
+
                 return !!companyRef && !this.isAdmin;
             },
             message: "A user can not be an admin and a company representative",

--- a/src/models/Account.js
+++ b/src/models/Account.js
@@ -11,6 +11,25 @@ const AccountSchema = new Schema({
         required: "Email address is required",
     },
     password: { type: String, required: true },
+    isAdmin: {
+        type: Boolean,
+        validate: {
+            validator: function(isAdmin) {
+                return isAdmin && !this.company;
+            },
+            message: "A user can not be an admin and a company representative",
+        },
+    },
+    company: {
+        type: Schema.Types.ObjectId, ref: "Company",
+        validate: {
+            validator: function(companyRef) {
+                return !!companyRef && !this.isAdmin;
+            },
+            message: "A user can not be an admin and a company representative",
+
+        },
+    },
 });
 
 AccountSchema.methods.validatePassword = async function(password) {

--- a/src/models/Account.js
+++ b/src/models/Account.js
@@ -13,21 +13,23 @@ const AccountSchema = new Schema({
     password: { type: String, required: true },
     isAdmin: {
         type: Boolean,
+        required: function() {
+            return !this.companyRef;
+        },
         validate: {
             validator: function(isAdmin) {
-                return !isAdmin && !!this.company;
+                return isAdmin && !this.company;
             },
             message: "A user can not be an admin and a company representative",
         },
     },
     company: {
         type: Schema.Types.ObjectId, ref: "Company",
+        required: function() {
+            return !this.isAdmin;
+        },
         validate: {
             validator: function(companyRef) {
-                console.log(companyRef);
-                console.log(this.isAdmin);
-
-
                 return !!companyRef && !this.isAdmin;
             },
             message: "A user can not be an admin and a company representative",

--- a/src/models/Account.js
+++ b/src/models/Account.js
@@ -3,8 +3,8 @@ const bcrypt = require("bcrypt");
 const { Schema } = mongoose;
 
 const AccountSchema = new Schema({
-    username: { type: String, unique: true },
-    password: { type: String },
+    username: { type: String, unique: true, maxlength: 20, minlength: 3, required: true },
+    password: { type: String, required: true },
 });
 
 AccountSchema.methods.validatePassword = async function(password) {

--- a/src/services/auth.js
+++ b/src/services/auth.js
@@ -6,14 +6,14 @@ class AuthService {
 
     }
 
-    async register(username, password) {
+    async register(email, password) {
         const account = await Account.create({
-            username,
+            email,
             password,
         });
 
         return {
-            username: account.username,
+            email: account.email,
         };
     }
 }

--- a/src/services/auth.js
+++ b/src/services/auth.js
@@ -10,6 +10,7 @@ class AuthService {
         const account = await Account.create({
             email,
             password,
+            isAdmin: true,
         });
 
         return {

--- a/test/account_schema.js
+++ b/test/account_schema.js
@@ -2,13 +2,13 @@ const Account = require("../src/models/Account");
 
 describe("# Account schema tests", () => {
     describe("Testing required fields", () => {
-        test("'username' is required", () => {
+        test("'email' is required", () => {
             const account = new Account({});
 
             return account.validate((err) => {
-                expect(err.errors.username).toBeDefined();
-                expect(err.errors.username).toHaveProperty("kind", "required");
-                expect(err.errors.username).toHaveProperty("message", "Path `username` is required.");
+                expect(err.errors.email).toBeDefined();
+                expect(err.errors.email).toHaveProperty("kind", "required");
+                expect(err.errors.email).toHaveProperty("message", "Email address is required");
             });
         });
 
@@ -19,46 +19,6 @@ describe("# Account schema tests", () => {
                 expect(err.errors.password).toBeDefined();
                 expect(err.errors.password).toHaveProperty("kind", "required");
                 expect(err.errors.password).toHaveProperty("message", "Path `password` is required.");
-            });
-        });
-    });
-
-    describe("Testing maximum and minimum lenghts for fields (checking string lengths)", () => {
-        describe("'username' must be between 3 and 20 characters", () => {
-            test("Below minimum should throw error", () => {
-                const username = "s";
-                const account = new Account({
-                    username,
-                });
-                return account.validate((err) => {
-                    expect(err.errors.username).toBeDefined();
-                    expect(err.errors.username).toHaveProperty("kind", "minlength");
-                    expect(err.errors.username)
-                        .toHaveProperty("message", `Path \`username\` (\`${username}\`) is shorter than the minimum allowed length (3).`);
-                });
-            });
-
-            test("Above miximum should throw error", () => {
-                const username = "thisisa20pluscharacterusermane";
-                const account = new Account({
-                    username,
-                });
-                return account.validate((err) => {
-                    expect(err.errors.username).toBeDefined();
-                    expect(err.errors.username).toHaveProperty("kind", "maxlength");
-                    expect(err.errors.username)
-                        .toHaveProperty("message", `Path \`username\` (\`${username}\`) is longer than the maximum allowed length (20).`);
-                });
-            });
-
-            test("Inside the range should not throw error", () => {
-                const username = "username";
-                const account = new Account({
-                    username,
-                });
-                return account.validate((err) => {
-                    expect(err.errors.username).not.toBeDefined();
-                });
             });
         });
     });

--- a/test/account_schema.js
+++ b/test/account_schema.js
@@ -1,0 +1,65 @@
+const Account = require("../src/models/Account");
+
+describe("# Account schema tests", () => {
+    describe("Testing required fields", () => {
+        test("'username' is required", () => {
+            const account = new Account({});
+
+            return account.validate((err) => {
+                expect(err.errors.username).toBeDefined();
+                expect(err.errors.username).toHaveProperty("kind", "required");
+                expect(err.errors.username).toHaveProperty("message", "Path `username` is required.");
+            });
+        });
+
+        test("'password' is required", () => {
+            const account = new Account({});
+
+            return account.validate((err) => {
+                expect(err.errors.password).toBeDefined();
+                expect(err.errors.password).toHaveProperty("kind", "required");
+                expect(err.errors.password).toHaveProperty("message", "Path `password` is required.");
+            });
+        });
+    });
+
+    describe("Testing maximum and minimum lenghts for fields (checking string lengths)", () => {
+        describe("'username' must be between 3 and 20 characters", () => {
+            test("Below minimum should throw error", () => {
+                const username = "s";
+                const account = new Account({
+                    username,
+                });
+                return account.validate((err) => {
+                    expect(err.errors.username).toBeDefined();
+                    expect(err.errors.username).toHaveProperty("kind", "minlength");
+                    expect(err.errors.username)
+                        .toHaveProperty("message", `Path \`username\` (\`${username}\`) is shorter than the minimum allowed length (3).`);
+                });
+            });
+
+            test("Above miximum should throw error", () => {
+                const username = "thisisa20pluscharacterusermane";
+                const account = new Account({
+                    username,
+                });
+                return account.validate((err) => {
+                    expect(err.errors.username).toBeDefined();
+                    expect(err.errors.username).toHaveProperty("kind", "maxlength");
+                    expect(err.errors.username)
+                        .toHaveProperty("message", `Path \`username\` (\`${username}\`) is longer than the maximum allowed length (20).`);
+                });
+            });
+
+            test("Inside the range should not throw error", () => {
+                const username = "username";
+                const account = new Account({
+                    username,
+                });
+                return account.validate((err) => {
+                    expect(err.errors.username).not.toBeDefined();
+                });
+            });
+        });
+    });
+});

--- a/test/end-to-end/auth.js
+++ b/test/end-to-end/auth.js
@@ -22,9 +22,10 @@ describe("Register endpoint test", () => {
                 });
             });
 
-            test("should be a String", async () => {
+            test("should be a valid email", async () => {
                 const params = {
-                    email: 123,
+                    email: "@123",
+                    password: "123456789",
                     god_token: test_god_token,
 
                 };
@@ -37,7 +38,7 @@ describe("Register endpoint test", () => {
                 expect(res.body).toHaveProperty("errors");
                 expect(res.body.errors).toContainEqual({
                     "location": "body",
-                    "msg": "Email must be a String",
+                    "msg": "Email must be valid",
                     "param": "email",
                     "value": params.email,
                 });

--- a/test/end-to-end/auth.js
+++ b/test/end-to-end/auth.js
@@ -2,6 +2,7 @@ const { ErrorTypes } = require("../../src/api/middleware/errorHandler");
 const Account = require("../../src/models/Account");
 const ValidatorTester = require("../utils/ValidatorTester");
 const withGodToken = require("../utils/GodToken");
+const ValidationReasons = require("../../src/api/middleware/validators/validationReasons");
 
 
 describe("Register endpoint test", () => {
@@ -100,7 +101,7 @@ describe("Login endpoint test", () => {
             expect(res.body).toHaveProperty("errors");
             expect(res.body.errors).toContainEqual({
                 "location": "body",
-                "msg": "Email already exists",
+                "msg": ValidationReasons.ALREADY_EXISTS("email"),
                 "param": "email",
                 "value": test_user.email,
             });

--- a/test/end-to-end/auth.js
+++ b/test/end-to-end/auth.js
@@ -3,7 +3,7 @@ const Account = require("../../src/models/Account");
 
 describe("Register endpoint test", () => {
     describe("Input Validation (unsuccessful registration)", () => {
-        describe("username", () => {
+        describe("email", () => {
             test("should be required", async () => {
                 const res = await request()
                     .post("/auth/register")
@@ -14,14 +14,14 @@ describe("Register endpoint test", () => {
                 expect(res.body).toHaveProperty("errors");
                 expect(res.body.errors).toContainEqual({
                     "location": "body",
-                    "msg": "Username is required",
-                    "param": "username",
+                    "msg": "Email is required",
+                    "param": "email",
                 });
             });
 
             test("should be a String", async () => {
                 const params = {
-                    username: 123,
+                    email: 123,
                 };
                 const res = await request()
                     .post("/auth/register")
@@ -32,9 +32,9 @@ describe("Register endpoint test", () => {
                 expect(res.body).toHaveProperty("errors");
                 expect(res.body.errors).toContainEqual({
                     "location": "body",
-                    "msg": "Username must be a String",
-                    "param": "username",
-                    "value": params.username,
+                    "msg": "Email must be a String",
+                    "param": "email",
+                    "value": params.email,
                 });
             });
         });
@@ -121,7 +121,7 @@ describe("Register endpoint test", () => {
 
         test("Should make a successful registration", async () => {
             const user = {
-                username: "user",
+                email: "user@email.com",
                 password: "password123",
             };
 
@@ -131,9 +131,9 @@ describe("Register endpoint test", () => {
 
             expect(res.status).toBe(200);
 
-            const registered_user = await Account.findOne({ username: user.username });
+            const registered_user = await Account.findOne({ email: user.email });
             expect(registered_user).toBeDefined();
-            expect(registered_user).toHaveProperty("username", user.username);
+            expect(registered_user).toHaveProperty("email", user.email);
         });
     });
 
@@ -142,16 +142,16 @@ describe("Register endpoint test", () => {
 describe("Using already resgistered user", () => {
     const test_agent = agent();
     const test_user = {
-        username: "user",
-        password: "password",
+        email: "user@email.com",
+        password: "password123",
     };
 
     beforeAll(async () => {
         await Account.deleteMany({});
-        await Account.create([test_user]);
+        await Account.create({ email: test_user.email, password: test_user.password });
     });
 
-    test("Cannot register with an already existing username", async () => {
+    test("Cannot register with an already existing email", async () => {
         const res = await request()
             .post("/auth/register")
             .send(test_user);
@@ -161,9 +161,9 @@ describe("Using already resgistered user", () => {
         expect(res.body).toHaveProperty("errors");
         expect(res.body.errors).toContainEqual({
             "location": "body",
-            "msg": "Username already exists",
-            "param": "username",
-            "value": test_user.username,
+            "msg": "Email already exists",
+            "param": "email",
+            "value": test_user.email,
         });
     });
 
@@ -194,7 +194,7 @@ describe("Using already resgistered user", () => {
             .send();
 
         expect(res.status).toBe(200);
-        expect(res.body).toHaveProperty("data.username", test_user.username);
+        expect(res.body).toHaveProperty("data.email", test_user.email);
     });
 
     test("Log out with registered account", async () => {

--- a/test/end-to-end/auth.js
+++ b/test/end-to-end/auth.js
@@ -1,13 +1,16 @@
 const { ErrorTypes } = require("../../src/api/middleware/errorHandler");
 const Account = require("../../src/models/Account");
 
+const test_god_token  = "testing_is_cool73";
 describe("Register endpoint test", () => {
     describe("Input Validation (unsuccessful registration)", () => {
         describe("email", () => {
             test("should be required", async () => {
                 const res = await request()
                     .post("/auth/register")
-                    .send({});
+                    .send({
+                        god_token: test_god_token,
+                    });
 
                 expect(res.status).toBe(422);
                 expect(res.body).toHaveProperty("error_code", ErrorTypes.VALIDATION_ERROR);
@@ -22,6 +25,8 @@ describe("Register endpoint test", () => {
             test("should be a String", async () => {
                 const params = {
                     email: 123,
+                    god_token: test_god_token,
+
                 };
                 const res = await request()
                     .post("/auth/register")
@@ -43,7 +48,9 @@ describe("Register endpoint test", () => {
             test("should be required", async () => {
                 const res = await request()
                     .post("/auth/register")
-                    .send({});
+                    .send({
+                        god_token: test_god_token,
+                    });
 
                 expect(res.status).toBe(422);
                 expect(res.body).toHaveProperty("error_code", ErrorTypes.VALIDATION_ERROR);
@@ -58,6 +65,7 @@ describe("Register endpoint test", () => {
             test("should be a String", async () => {
                 const params = {
                     password: 123,
+                    god_token: test_god_token,
                 };
                 const res = await request()
                     .post("/auth/register")
@@ -77,6 +85,7 @@ describe("Register endpoint test", () => {
             test("should have more than 8 characters", async () => {
                 const params = {
                     password: "12345",
+                    god_token: test_god_token,
                 };
                 const res = await request()
                     .post("/auth/register")
@@ -96,6 +105,7 @@ describe("Register endpoint test", () => {
             test("should contain a number", async () => {
                 const params = {
                     password: "password",
+                    god_token: test_god_token,
                 };
                 const res = await request()
                     .post("/auth/register")
@@ -119,10 +129,24 @@ describe("Register endpoint test", () => {
             await Account.deleteMany({});
         });
 
+        test("Should return forbidden", async () => {
+            const user = {
+                email: "user@email.com",
+                password: "password123",
+            };
+
+            const res = await request()
+                .post("/auth/register")
+                .send(user);
+
+            expect(res.status).toBe(401);
+        });
+
         test("Should make a successful registration", async () => {
             const user = {
                 email: "user@email.com",
                 password: "password123",
+                god_token: test_god_token,
             };
 
             const res = await request()
@@ -144,6 +168,7 @@ describe("Using already resgistered user", () => {
     const test_user = {
         email: "user@email.com",
         password: "password123",
+        god_token: test_god_token,
     };
 
     beforeAll(async () => {

--- a/test/end-to-end/auth.js
+++ b/test/end-to-end/auth.js
@@ -173,7 +173,7 @@ describe("Using already resgistered user", () => {
 
     beforeAll(async () => {
         await Account.deleteMany({});
-        await Account.create({ email: test_user.email, password: test_user.password });
+        await Account.create({ email: test_user.email, password: test_user.password, isAdmin: true });
     });
 
     test("Cannot register with an already existing email", async () => {

--- a/test/end-to-end/offer.js
+++ b/test/end-to-end/offer.js
@@ -5,12 +5,8 @@ const FieldTypes = require("../../src/models/FieldTypes");
 const TechnologyTypes = require("../../src/models/TechnologyTypes");
 const { ErrorTypes } = require("../../src/api/middleware/errorHandler");
 const ValidatorTester = require("../utils/ValidatorTester");
+const withGodToken = require("../utils/GodToken");
 
-// ------- Test helper functions for generating test code --------
-// TODO: Generalize these even more for usage in other tests
-// (pass endpoint as argument, maybe as function returning function for usage in the whole test suite for an endpoint)
-
-const withGodToken = (params) => ({ ...params, god_token: "testing_is_cool73" });
 //----------------------------------------------------------------
 
 describe("Offer endpoint tests", () => {

--- a/test/end-to-end/offer.js
+++ b/test/end-to-end/offer.js
@@ -10,48 +10,48 @@ const ValidatorTester = require("../utils/ValidatorTester");
 // TODO: Generalize these even more for usage in other tests
 // (pass endpoint as argument, maybe as function returning function for usage in the whole test suite for an endpoint)
 
-const withAdminToken = (params) => ({ ...params, admin_token: "testing_is_cool73" });
+const withGodToken = (params) => ({ ...params, god_token: "testing_is_cool73" });
 //----------------------------------------------------------------
 
 describe("Offer endpoint tests", () => {
     describe("POST /offer", () => {
 
         describe("Authentication", () => {
-            describe("creating offers requires admin permissions", () => {
-                test("should fail when admin token not provided", async () => {
+            describe("creating offers requires god permissions", () => {
+                test("should fail when god token not provided", async () => {
                     const res = await request()
                         .post("/offer")
                         .send({});
 
                     expect(res.status).toBe(401);
                     expect(res.body).toHaveProperty("error_code", ErrorTypes.FORBIDDEN);
-                    expect(res.body).toHaveProperty("reason", "Invalid admin token");
+                    expect(res.body).toHaveProperty("reason", "Invalid god token");
                 });
 
-                test("should fail when admin token is incorrect", async () => {
+                test("should fail when god token is incorrect", async () => {
                     const res = await request()
                         .post("/offer")
                         .send({
-                            admin_token: "NotAValidAdminToken!!12345",
+                            god_token: "NotAValidGodToken!!12345",
                         });
 
                     expect(res.status).toBe(401);
                     expect(res.body).toHaveProperty("error_code", ErrorTypes.FORBIDDEN);
-                    expect(res.body).toHaveProperty("reason", "Invalid admin token");
+                    expect(res.body).toHaveProperty("reason", "Invalid god token");
                 });
 
-                test("should succeed when admin token is correct", async () => {
+                test("should succeed when god token is correct", async () => {
                     const params = {};
                     const res = await request()
                         .post("/offer")
-                        .send(withAdminToken(params));
+                        .send(withGodToken(params));
 
                     expect(res.status).not.toBe(401);
                 });
             });
         });
 
-        const EndpointValidatorTester = ValidatorTester((params) => request().post("/offer").send(withAdminToken(params)));
+        const EndpointValidatorTester = ValidatorTester((params) => request().post("/offer").send(withGodToken(params)));
         const BodyValidatorTester = EndpointValidatorTester("body");
 
         describe("Input Validation", () => {
@@ -166,7 +166,7 @@ describe("Offer endpoint tests", () => {
 
                 const res = await request()
                     .post("/offer")
-                    .send(withAdminToken(offer));
+                    .send(withGodToken(offer));
 
                 expect(res.status).toBe(200);
                 const created_offer_id = res.body._id;
@@ -209,7 +209,7 @@ describe("Offer endpoint tests", () => {
             test("publishDate defaults to the current time if not provided", async () => {
                 const res = await request()
                     .post("/offer")
-                    .send(withAdminToken(offer));
+                    .send(withGodToken(offer));
 
                 expect(res.status).toBe(200);
                 const created_offer_id = res.body._id;

--- a/test/utils/GodToken.js
+++ b/test/utils/GodToken.js
@@ -1,0 +1,2 @@
+const withGodToken = (params) => ({ ...params, god_token: "testing_is_cool73" });
+module.exports = withGodToken;

--- a/test/utils/ValidatorTester.js
+++ b/test/utils/ValidatorTester.js
@@ -181,6 +181,67 @@ const ValidatorTester = (requestEndpoint) => (location) => (field_name) => ({
             });
         });
     },
+
+    hasMinLength: (min_length) => {
+        test(`should not be smaller than ${min_length} characters`, async () => {
+            const params = {
+                [field_name]: "a".repeat(min_length - 1),
+            };
+
+            const res = await requestEndpoint(params);
+
+            expect(res.status).toBe(422);
+            expect(res.body).toHaveProperty("error_code", ErrorTypes.VALIDATION_ERROR);
+            expect(res.body).toHaveProperty("errors");
+            expect(res.body.errors).toContainEqual({
+                "location": location,
+                "msg": ValidationReasons.TOO_SHORT(min_length),
+                "param": field_name,
+                "value": params[field_name],
+            });
+        });
+    },
+
+
+    mustBeEmail: () => {
+        test("should be a valid email", async () => {
+            const params = {
+                [field_name]: "@aaa",
+            };
+
+            const res = await requestEndpoint(params);
+
+            expect(res.status).toBe(422);
+            expect(res.body).toHaveProperty("error_code", ErrorTypes.VALIDATION_ERROR);
+            expect(res.body).toHaveProperty("errors");
+            expect(res.body.errors).toContainEqual({
+                "location": location,
+                "msg": ValidationReasons.EMAIL,
+                "param": field_name,
+                "value": params[field_name],
+            });
+        });
+    },
+
+    hasNumber: () => {
+        test("should have a number", async () => {
+            const params = {
+                [field_name]: "aaa",
+            };
+
+            const res = await requestEndpoint(params);
+
+            expect(res.status).toBe(422);
+            expect(res.body).toHaveProperty("error_code", ErrorTypes.VALIDATION_ERROR);
+            expect(res.body).toHaveProperty("errors");
+            expect(res.body.errors).toContainEqual({
+                "location": location,
+                "msg": ValidationReasons.HAVE_NUMBER,
+                "param": field_name,
+                "value": params[field_name],
+            });
+        });
+    },
 });
 
 module.exports = ValidatorTester;


### PR DESCRIPTION
Closes #52 

* Added `isAdmin` and `company` fields to Account Schema
* Force only one of the fields `isAdmin` and `company` to be required
* Rename Admin Token to God Token
* Make register endpoint force the created user to be an admin
* Only the god user can create admins