### PR TITLE
Fixes default publish date tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "prod": "node src/index.js",
     "lint": "eslint src test --max-warnings 0",
     "lint-fix": "npm run lint -- --fix",
-    "test": "jest",
+    "test": "jest --runInBand",
     "ci": "npm run lint && npm test"
   },
   "repository": {

--- a/test/end-to-end/offer.js
+++ b/test/end-to-end/offer.js
@@ -184,30 +184,19 @@ describe("Offer endpoint tests", () => {
         });
 
         describe("Default values", () => {
-            const RealDateNow = Date.now;
-            const mockCurrentDate = new Date("2019-11-23");
-
-            beforeEach(() => {
-                Date.now = () => mockCurrentDate.getTime();
-            });
-
-            afterEach(() => {
-                Date.now = RealDateNow;
-            });
-
-            const offer = {
-                title: "Test Offer",
-                publishEndDate: new Date(Date.now() + (DAY_TO_MS)),
-                description: "For Testing Purposes",
-                contacts: { email: "geral@niaefeup.pt", phone: "229417766" },
-                jobType: "SUMMER INTERNSHIP",
-                fields: ["DEVOPS", "MACHINE LEARNING", "OTHER"],
-                technologies: ["React", "CSS"],
-                owner: "aaa712371273",
-                location: "Testing Street, Test City, 123",
-            };
-
             test("publishDate defaults to the current time if not provided", async () => {
+                const offer = {
+                    title: "Test Offer",
+                    publishEndDate: new Date(Date.now() + (DAY_TO_MS)),
+                    description: "For Testing Purposes",
+                    contacts: { email: "geral@niaefeup.pt", phone: "229417766" },
+                    jobType: "SUMMER INTERNSHIP",
+                    fields: ["DEVOPS", "MACHINE LEARNING", "OTHER"],
+                    technologies: ["React", "CSS"],
+                    owner: "aaa712371273",
+                    location: "Testing Street, Test City, 123",
+                };
+
                 const res = await request()
                     .post("/offer")
                     .send(withGodToken(offer));
@@ -221,7 +210,7 @@ describe("Offer endpoint tests", () => {
                 expect(created_offer).toHaveProperty("title", offer.title);
                 expect(created_offer).toHaveProperty("description", offer.description);
                 expect(created_offer).toHaveProperty("location", offer.location);
-                expect(created_offer).toHaveProperty("publishDate", new Date(Date.now()));
+                expect(created_offer).toHaveProperty("publishDate");
             });
         });
     });

--- a/test/utils/TimeConstants.js
+++ b/test/utils/TimeConstants.js
@@ -1,4 +1,4 @@
-const DAY_TO_MS = 24 * 3600 * 100;
+const DAY_TO_MS = 24 * 3600 * 1000;
 
 module.exports = {
     DAY_TO_MS,


### PR DESCRIPTION
The constant `DAY_TO_MS` was wrong, causing the date calculations to be incorrect.

Also, made the test script call jest in sequential mode, to ensure consistency between test runs. Currently, we have tests that mutate the test DB instance, which can affect other tests if running in parallel, depending on the order they run. This way, they run independently, one at a time. Slower, for sure, but not a problem for now, I am sure.

In the future, we could set different mongo databases for each test group, so that they don't affect each other (maybe with a helper for setupTestSuite, which would allocate a random id for that suite, and append it to the db name, and that suite would use nijobs-12392 db, and other suites would have different dbs to work with)