### PR TITLE
Company Applications Review

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
     environment:
       - DB_HOST=mongo
     volumes:
-      - ./src:/usr/src/nijobs-be/src
+      - ./src:/usr/src/app/src
     depends_on:
       - mongo
   test:

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -3,6 +3,7 @@ const auth = require("./routes/auth");
 const example = require("./routes/example");
 const offer = require("./routes/offer");
 const application = require("./routes/application");
+const review = require("./routes/review");
 
 module.exports = () => {
     const app = Router();
@@ -10,6 +11,7 @@ module.exports = () => {
     example(app);
     offer(app);
     application(app);
+    review(app);
 
     return app;
 };

--- a/src/api/middleware/errorHandler.js
+++ b/src/api/middleware/errorHandler.js
@@ -8,6 +8,11 @@ const ErrorTypes = Object.freeze({
     UNEXPECTED_ERROR: 99,
 });
 
+const buildErrorResponse = (error_code, errors) => ({
+    error_code,
+    errors,
+});
+
 // Automatically run validators in order to have a standardized error response
 const useExpressValidators = (validators) => async (req, res, next) => {
     await Promise.all(validators.map((validator) => validator.run(req)));
@@ -19,10 +24,7 @@ const useExpressValidators = (validators) => async (req, res, next) => {
 
     return res
         .status(HTTPStatus.UNPROCESSABLE_ENTITY)
-        .json({
-            error_code: ErrorTypes.VALIDATION_ERROR,
-            errors: errors.array(),
-        });
+        .json(buildErrorResponse(ErrorTypes.VALIDATION_ERROR, errors.array()));
 };
 
 const defaultErrorHandler = (err, req, res, _) => {
@@ -39,4 +41,5 @@ module.exports = {
     defaultErrorHandler,
     ErrorTypes,
     useExpressValidators,
+    buildErrorResponse,
 };

--- a/src/api/middleware/validators/application.js
+++ b/src/api/middleware/validators/application.js
@@ -6,7 +6,7 @@ const { checkDuplicatedEmail, stringOrValuesInSet } = require("./validatorUtils"
 const CompanyApplicationConstants = require("../../../models/constants/CompanyApplication");
 const CompanyConstants = require("../../../models/constants/Company");
 const AccountConstants = require("../../../models/constants/Account");
-const { applicationUniqueness, isApprovable, isRejectable } = require("../../../models/CompanyApplication");
+const { applicationUniqueness } = require("../../../models/CompanyApplication");
 const mongoose = require("mongoose");
 const ApplicationStatus = require("../../../models/constants/ApplicationStatus");
 
@@ -49,14 +49,12 @@ const approve = useExpressValidators([
     param("id", ValidationReasons.DEFAULT)
         .exists().withMessage(ValidationReasons.REQUIRED).bail()
         .custom((value) => mongoose.Types.ObjectId.isValid(value))
-        .withMessage(ValidationReasons.OBJECT_ID).bail()
-        .custom(isApprovable),
+        .withMessage(ValidationReasons.OBJECT_ID).bail(),
 ]);
 
 const reject = useExpressValidators([
     param("id", ValidationReasons.DEFAULT)
-        .exists().withMessage(ValidationReasons.REQUIRED).bail()
-        .custom(isRejectable),
+        .exists().withMessage(ValidationReasons.REQUIRED).bail(),
     body("rejectReason", ValidationReasons.DEFAULT)
         .exists().withMessage(ValidationReasons.REQUIRED).bail()
         .isString().withMessage(ValidationReasons.STRING)

--- a/src/api/middleware/validators/application.js
+++ b/src/api/middleware/validators/application.js
@@ -56,6 +56,13 @@ const reject = useExpressValidators([
     param("id", ValidationReasons.DEFAULT)
         .exists().withMessage(ValidationReasons.REQUIRED).bail()
         .custom(isRejectable),
+    body("rejectReason", ValidationReasons.DEFAULT)
+        .exists().withMessage(ValidationReasons.REQUIRED).bail()
+        .isString().withMessage(ValidationReasons.STRING)
+        .isLength({ max: CompanyApplicationConstants.rejectReason.max_length })
+        .withMessage(ValidationReasons.TOO_LONG(CompanyApplicationConstants.rejectReason.max_length))
+        .isLength({ min: CompanyApplicationConstants.rejectReason.min_length })
+        .withMessage(ValidationReasons.TOO_SHORT(CompanyApplicationConstants.rejectReason.min_length)),
 ]);
 
 

--- a/src/api/middleware/validators/application.js
+++ b/src/api/middleware/validators/application.js
@@ -1,4 +1,4 @@
-const { body } = require("express-validator");
+const { body, param } = require("express-validator");
 
 const { useExpressValidators } = require("../errorHandler");
 const ValidationReasons = require("./validationReasons");
@@ -6,7 +6,8 @@ const { checkDuplicatedEmail } = require("./validatorUtils");
 const CompanyApplicationConstants = require("../../../models/constants/CompanyApplication");
 const CompanyConstants = require("../../../models/constants/Company");
 const AccountConstants = require("../../../models/constants/Account");
-const { applicationUniqueness } = require("../../../models/CompanyApplication");
+const { applicationUniqueness, isApprovable, isRejectable } = require("../../../models/CompanyApplication");
+const mongoose = require("mongoose");
 
 const create = useExpressValidators([
     body("email", ValidationReasons.DEFAULT)
@@ -43,5 +44,19 @@ const create = useExpressValidators([
         .trim(),
 ]);
 
+const approve = useExpressValidators([
+    param("id", ValidationReasons.DEFAULT)
+        .exists().withMessage(ValidationReasons.REQUIRED).bail()
+        .custom((value) => mongoose.Types.ObjectId.isValid(value))
+        .withMessage(ValidationReasons.OBJECT_ID).bail()
+        .custom(isApprovable),
+]);
 
-module.exports = { create };
+const reject = useExpressValidators([
+    param("id", ValidationReasons.DEFAULT)
+        .exists().withMessage(ValidationReasons.REQUIRED).bail()
+        .custom(isRejectable),
+]);
+
+
+module.exports = { create, approve, reject };

--- a/src/api/middleware/validators/application.js
+++ b/src/api/middleware/validators/application.js
@@ -8,6 +8,7 @@ const CompanyConstants = require("../../../models/constants/Company");
 const AccountConstants = require("../../../models/constants/Account");
 const { applicationUniqueness, isApprovable, isRejectable } = require("../../../models/CompanyApplication");
 const mongoose = require("mongoose");
+const ApplicationStatus = require("../../../models/constants/ApplicationStatus");
 
 const create = useExpressValidators([
     body("email", ValidationReasons.DEFAULT)
@@ -66,9 +67,20 @@ const reject = useExpressValidators([
 ]);
 
 const search = useExpressValidators([
-    body("filters", ValidationReasons.DEFAULT)
-        .optional(),
-    // TODO
+    body("filters.companyName", ValidationReasons.DEFAULT)
+        .optional()
+        .isString().withMessage(ValidationReasons.STRING),
+    body("filters.state", ValidationReasons.DEFAULT)
+        .optional()
+        .isString().withMessage(ValidationReasons.STRING)
+        .isIn(ApplicationStatus)
+        .withMessage(ValidationReasons.IN_ARRAY(Object.keys(ApplicationStatus))),
+    body("filters.submissionDate.from", ValidationReasons.DEFAULT)
+        .optional()
+        .isISO8601().withMessage(ValidationReasons.DATE),
+    body("filters.submissionDate.to", ValidationReasons.DEFAULT)
+        .optional()
+        .isISO8601().withMessage(ValidationReasons.DATE),
 ]);
 
 module.exports = {

--- a/src/api/middleware/validators/application.js
+++ b/src/api/middleware/validators/application.js
@@ -6,7 +6,7 @@ const { checkDuplicatedEmail, stringOrValuesInSet } = require("./validatorUtils"
 const CompanyApplicationConstants = require("../../../models/constants/CompanyApplication");
 const CompanyConstants = require("../../../models/constants/Company");
 const AccountConstants = require("../../../models/constants/Account");
-const { applicationUniqueness } = require("../../../models/CompanyApplication");
+const { applicationUniqueness, CompanyApplicationProps } = require("../../../models/CompanyApplication");
 const mongoose = require("mongoose");
 const ApplicationStatus = require("../../../models/constants/ApplicationStatus");
 
@@ -66,6 +66,25 @@ const reject = useExpressValidators([
         .withMessage(ValidationReasons.TOO_SHORT(CompanyApplicationConstants.rejectReason.min_length)),
 ]);
 
+const sortByParamValidator = (val) => {
+
+    if (typeof val === "string") return true;
+
+    if (typeof val === "object") {
+
+        for (const field in val) {
+            if (!CompanyApplicationProps.hasOwnProperty(field)) {
+                throw new Error(ValidationReasons.IN_ARRAY(Object.keys(CompanyApplicationProps), field));
+            }
+            if (val[field] !== "desc" && val[field] !== "asc") {
+                throw new Error(ValidationReasons.IN_ARRAY(Object.keys(CompanyApplicationProps), val[field]));
+            }
+        }
+    }
+    return true;
+};
+
+
 const search = useExpressValidators([
     param("limit", ValidationReasons.DEFAULT)
         .optional()
@@ -87,6 +106,9 @@ const search = useExpressValidators([
     body("filters.submissionDate.to", ValidationReasons.DEFAULT)
         .optional()
         .isISO8601().withMessage(ValidationReasons.DATE),
+    body("sortBy", ValidationReasons.DEFAULT)
+        .optional()
+        .custom(sortByParamValidator),
 ]);
 
 module.exports = {

--- a/src/api/middleware/validators/application.js
+++ b/src/api/middleware/validators/application.js
@@ -10,6 +10,8 @@ const { applicationUniqueness } = require("../../../models/CompanyApplication");
 const mongoose = require("mongoose");
 const ApplicationStatus = require("../../../models/constants/ApplicationStatus");
 
+const MAX_LIMIT_RESULTS = 100;
+
 const create = useExpressValidators([
     body("email", ValidationReasons.DEFAULT)
         .exists().withMessage(ValidationReasons.REQUIRED).bail()
@@ -65,6 +67,14 @@ const reject = useExpressValidators([
 ]);
 
 const search = useExpressValidators([
+    param("limit", ValidationReasons.DEFAULT)
+        .optional()
+        .isInt({ min: 1, max: MAX_LIMIT_RESULTS })
+        .withMessage(ValidationReasons.MAX(MAX_LIMIT_RESULTS)),
+    param("offset", ValidationReasons.DEFAULT)
+        .optional()
+        .isInt({ min: 0 })
+        .withMessage(ValidationReasons.MIN(0)),
     body("filters.companyName", ValidationReasons.DEFAULT)
         .optional()
         .isString().withMessage(ValidationReasons.STRING),
@@ -84,4 +94,5 @@ module.exports = {
     approve,
     reject,
     search,
+    MAX_LIMIT_RESULTS,
 };

--- a/src/api/middleware/validators/application.js
+++ b/src/api/middleware/validators/application.js
@@ -2,7 +2,7 @@ const { body, param } = require("express-validator");
 
 const { useExpressValidators } = require("../errorHandler");
 const ValidationReasons = require("./validationReasons");
-const { checkDuplicatedEmail } = require("./validatorUtils");
+const { checkDuplicatedEmail, stringOrValuesInSet } = require("./validatorUtils");
 const CompanyApplicationConstants = require("../../../models/constants/CompanyApplication");
 const CompanyConstants = require("../../../models/constants/Company");
 const AccountConstants = require("../../../models/constants/Account");
@@ -72,9 +72,7 @@ const search = useExpressValidators([
         .isString().withMessage(ValidationReasons.STRING),
     body("filters.state", ValidationReasons.DEFAULT)
         .optional()
-        .isString().withMessage(ValidationReasons.STRING)
-        .isIn(ApplicationStatus)
-        .withMessage(ValidationReasons.IN_ARRAY(Object.keys(ApplicationStatus))),
+        .custom(stringOrValuesInSet(Object.keys(ApplicationStatus))),
     body("filters.submissionDate.from", ValidationReasons.DEFAULT)
         .optional()
         .isISO8601().withMessage(ValidationReasons.DATE),

--- a/src/api/middleware/validators/application.js
+++ b/src/api/middleware/validators/application.js
@@ -65,5 +65,15 @@ const reject = useExpressValidators([
         .withMessage(ValidationReasons.TOO_SHORT(CompanyApplicationConstants.rejectReason.min_length)),
 ]);
 
+const search = useExpressValidators([
+    body("filters", ValidationReasons.DEFAULT)
+        .optional(),
+    // TODO
+]);
 
-module.exports = { create, approve, reject };
+module.exports = {
+    create,
+    approve,
+    reject,
+    search,
+};

--- a/src/api/middleware/validators/validationReasons.js
+++ b/src/api/middleware/validators/validationReasons.js
@@ -4,6 +4,7 @@ const ValidationReasons = Object.freeze({
     TOO_LONG: (len) => `max-length-exceeded:${len}`,
     TOO_SHORT: (len) => `below-min-length:${len}`,
     STRING: "must-be-string",
+    ARRAY: "must-be-array",
     DATE: "must-be-ISO8601-date",
     INT: "must-be-int",
     BOOLEAN: "must-be-boolean",

--- a/src/api/middleware/validators/validationReasons.js
+++ b/src/api/middleware/validators/validationReasons.js
@@ -1,6 +1,8 @@
 const ValidationReasons = Object.freeze({
     DEFAULT: "invalid",
     REQUIRED: "required",
+    MIN: (val) => `must-be-greater-than-${val}`,
+    MAX: (val) => `must-be-lower-than-${val}`,
     TOO_LONG: (len) => `max-length-exceeded:${len}`,
     TOO_SHORT: (len) => `below-min-length:${len}`,
     STRING: "must-be-string",

--- a/src/api/middleware/validators/validationReasons.js
+++ b/src/api/middleware/validators/validationReasons.js
@@ -10,7 +10,7 @@ const ValidationReasons = Object.freeze({
     DATE: "must-be-ISO8601-date",
     INT: "must-be-int",
     BOOLEAN: "must-be-boolean",
-    IN_ARRAY: (vals) => `must-be-in:[${vals}]`,
+    IN_ARRAY: (vals, field) => `${field ? `${field}:` : ""}must-be-in:[${vals}]`,
     ARRAY_SIZE: (min, max) => `size-must-be-between:[${min},${max}]`,
     OBJECT_ID: "must-be-a-valid-id",
     EMAIL: "must-be-a-valid-email",

--- a/src/api/middleware/validators/validationReasons.js
+++ b/src/api/middleware/validators/validationReasons.js
@@ -9,6 +9,7 @@ const ValidationReasons = Object.freeze({
     BOOLEAN: "must-be-boolean",
     IN_ARRAY: (vals) => `must-be-in:[${vals}]`,
     ARRAY_SIZE: (min, max) => `size-must-be-between:[${min},${max}]`,
+    OBJECT_ID: "must-be-a-valid-id",
     EMAIL: "must-be-a-valid-email",
     HAS_NUMBER: "must-contain-number",
     ALREADY_EXISTS: (variable) => `${variable}-already-exists`,

--- a/src/api/middleware/validators/validatorUtils.js
+++ b/src/api/middleware/validators/validatorUtils.js
@@ -16,6 +16,29 @@ const valuesInSet = (set) => (arr) => {
 };
 
 /**
+ * Returns a validator that checks whether all of the elements of an array belong to the provided set of values
+ * @param {Array} set
+ */
+const stringOrValuesInSet = (set) => (val) => {
+
+    const checkValid = (value) => (arr) => {
+        if (!arr.includes(value)) {
+            throw new Error(ValidationReasons.IN_ARRAY(set));
+        }
+    };
+
+    if (typeof val === "string") {
+        checkValid(val)(set);
+    } else {
+        for (const item of val) {
+            checkValid(item)(set);
+        }
+    }
+
+    return true;
+};
+
+/**
  * Throws an error if it already exists a account with the given email.
  * @param {String} email
  */
@@ -29,5 +52,6 @@ const checkDuplicatedEmail = async (email) => {
 
 module.exports = {
     valuesInSet,
+    stringOrValuesInSet,
     checkDuplicatedEmail,
 };

--- a/src/api/middleware/validators/validatorUtils.js
+++ b/src/api/middleware/validators/validatorUtils.js
@@ -21,17 +21,17 @@ const valuesInSet = (set) => (arr) => {
  */
 const stringOrValuesInSet = (set) => (val) => {
 
-    const checkValid = (value) => (arr) => {
+    const checkValid = (value, arr) => {
         if (!arr.includes(value)) {
             throw new Error(ValidationReasons.IN_ARRAY(set));
         }
     };
 
     if (typeof val === "string") {
-        checkValid(val)(set);
+        checkValid(val, set);
     } else {
         for (const item of val) {
-            checkValid(item)(set);
+            checkValid(item, set);
         }
     }
 

--- a/src/api/routes/auth.js
+++ b/src/api/routes/auth.js
@@ -4,7 +4,7 @@ const passport = require("passport");
 
 const { authRequired, isGod } = require("../middleware/auth");
 const validators = require("../middleware/validators/auth");
-const AuthService = require("../../services/auth");
+const AccountService = require("../../services/account");
 
 
 const router = Router();
@@ -38,7 +38,7 @@ module.exports = (app) => {
 
         // Inserting user into db and replying with success or not
         try {
-            const data = await (new AuthService()).registerAdmin(email, password);
+            const data = await (new AccountService()).registerAdmin(email, password);
 
             return res.status(HTTPStatus.OK).json({
                 data,

--- a/src/api/routes/auth.js
+++ b/src/api/routes/auth.js
@@ -38,7 +38,7 @@ module.exports = (app) => {
 
         // Inserting user into db and replying with success or not
         try {
-            const data = await (new AuthService()).register(email, password);
+            const data = await (new AuthService()).registerAdmin(email, password);
 
             return res.status(HTTPStatus.OK).json({
                 data,

--- a/src/api/routes/review.js
+++ b/src/api/routes/review.js
@@ -4,6 +4,7 @@ const authMiddleware = require("../middleware/auth");
 const companyApplicationValidators = require("../middleware/validators/application");
 const ApplicationService = require("../../services/application");
 const mongoose = require("mongoose");
+const AuthService = require("../../services/auth");
 
 const router = Router();
 
@@ -36,8 +37,13 @@ module.exports = (app) => {
         async (req, res, next) => {
 
             try {
+                // TODO use mongoose transaction to handle cancelation of approval if account creation fails
+                // https://medium.com/cashpositive/the-hitchhikers-guide-to-mongodb-transactions-with-mongoose-5bf8a6e22033
                 const application = await (new ApplicationService()).approve(mongoose.Types.ObjectId(req.params.id));
-                return res.json(application);
+
+                const account = await (new AuthService()).registerCompany(application.email, application.password, application.companyName);
+
+                return res.json(account);
             } catch (err) {
                 return next(err);
             }

--- a/src/api/routes/review.js
+++ b/src/api/routes/review.js
@@ -5,6 +5,10 @@ const companyApplicationValidators = require("../middleware/validators/applicati
 const ApplicationService = require("../../services/application");
 const mongoose = require("mongoose");
 
+const HTTPStatus = require("http-status-codes");
+const { buildErrorResponse, ErrorTypes } = require("../middleware/errorHandler");
+
+
 const router = Router();
 
 module.exports = (app) => {
@@ -37,7 +41,18 @@ module.exports = (app) => {
                 const { account } = await (new ApplicationService()).approve(mongoose.Types.ObjectId(req.params.id));
                 return res.json(account);
             } catch (err) {
-                return next(err);
+                if (err instanceof ApplicationService.CompanyApplicationNotFound) {
+                    return res
+                        .status(HTTPStatus.NOT_FOUND)
+                        .json(buildErrorResponse(ErrorTypes.VALIDATION_ERROR, [err.message]));
+                } else if (err instanceof ApplicationService.CompanyApplicationAlreadyReiewed) {
+                    return res
+                        .status(HTTPStatus.CONFLICT)
+                        .json(buildErrorResponse(ErrorTypes.VALIDATION_ERROR, [err.message]));
+
+                } else {
+                    return next(err);
+                }
             }
         });
 
@@ -54,7 +69,18 @@ module.exports = (app) => {
                 const application = await (new ApplicationService()).reject(mongoose.Types.ObjectId(req.params.id), req.body.rejectReason);
                 return res.json(application);
             } catch (err) {
-                return next(err);
+                if (err instanceof ApplicationService.CompanyApplicationNotFound) {
+                    return res
+                        .status(HTTPStatus.NOT_FOUND)
+                        .json(buildErrorResponse(ErrorTypes.VALIDATION_ERROR, [err.message]));
+                } else if (err instanceof ApplicationService.CompanyApplicationAlreadyReiewed) {
+                    return res
+                        .status(HTTPStatus.CONFLICT)
+                        .json(buildErrorResponse(ErrorTypes.VALIDATION_ERROR, [err.message]));
+
+                } else {
+                    return next(err);
+                }
             }
         });
 };

--- a/src/api/routes/review.js
+++ b/src/api/routes/review.js
@@ -4,7 +4,6 @@ const authMiddleware = require("../middleware/auth");
 const companyApplicationValidators = require("../middleware/validators/application");
 const ApplicationService = require("../../services/application");
 const mongoose = require("mongoose");
-const AuthService = require("../../services/auth");
 
 const router = Router();
 
@@ -37,12 +36,7 @@ module.exports = (app) => {
         async (req, res, next) => {
 
             try {
-                // TODO use mongoose transaction to handle cancelation of approval if account creation fails
-                // https://medium.com/cashpositive/the-hitchhikers-guide-to-mongodb-transactions-with-mongoose-5bf8a6e22033
-                const application = await (new ApplicationService()).approve(mongoose.Types.ObjectId(req.params.id));
-
-                const account = await (new AuthService()).registerCompany(application.email, application.password, application.companyName);
-
+                const { account } = await (new ApplicationService()).approve(mongoose.Types.ObjectId(req.params.id));
                 return res.json(account);
             } catch (err) {
                 return next(err);
@@ -59,7 +53,7 @@ module.exports = (app) => {
         async (req, res, next) => {
 
             try {
-                const application = await (new ApplicationService()).reject(mongoose.Types.ObjectId(req.params.id));
+                const application = await (new ApplicationService()).reject(mongoose.Types.ObjectId(req.params.id), req.body.rejectReason);
                 return res.json(application);
             } catch (err) {
                 return next(err);

--- a/src/api/routes/review.js
+++ b/src/api/routes/review.js
@@ -26,6 +26,21 @@ module.exports = (app) => {
             }
         });
 
+
+    /**
+     * Searches for a Company Application, with provided filters
+     */
+    router.get("/search", companyApplicationValidators.search, async (req, res, next) => {
+
+        try {
+            // This is safe since the service is destructuring the passed object and the fields have been validated
+            const applications = await (new ApplicationService()).find(req.body.filters);
+            return res.json(applications);
+        } catch (err) {
+            return next(err);
+        }
+    });
+
     /**
      * Approves a Pending Company Application
      */

--- a/src/api/routes/review.js
+++ b/src/api/routes/review.js
@@ -1,0 +1,62 @@
+const { Router } = require("express");
+
+const authMiddleware = require("../middleware/auth");
+const companyApplicationValidators = require("../middleware/validators/application");
+const ApplicationService = require("../../services/application");
+const mongoose = require("mongoose");
+
+const router = Router();
+
+module.exports = (app) => {
+    app.use("/applications/company", router);
+
+    /**
+     * Approves a Pending Company Application
+     */
+    router.get("/",
+        authMiddleware.authRequired,
+        authMiddleware.isAdmin,
+        async (req, res, next) => {
+
+            try {
+                const applications = await (new ApplicationService()).findAll();
+                return res.json(applications);
+            } catch (err) {
+                return next(err);
+            }
+        });
+
+    /**
+     * Approves a Pending Company Application
+     */
+    router.post("/:id/approve",
+        authMiddleware.authRequired,
+        authMiddleware.isAdmin,
+        companyApplicationValidators.approve,
+        async (req, res, next) => {
+
+            try {
+                const application = await (new ApplicationService()).approve(mongoose.Types.ObjectId(req.params.id));
+                return res.json(application);
+            } catch (err) {
+                return next(err);
+            }
+        });
+
+    /**
+     * Rejects a Pending Company Application
+     */
+    router.post("/:id/reject",
+        authMiddleware.authRequired,
+        authMiddleware.isAdmin,
+        companyApplicationValidators.reject,
+        async (req, res, next) => {
+
+            try {
+                const application = await (new ApplicationService()).reject(mongoose.Types.ObjectId(req.params.id));
+                return res.json(application);
+            } catch (err) {
+                return next(err);
+            }
+        });
+};

--- a/src/api/routes/review.js
+++ b/src/api/routes/review.js
@@ -11,23 +11,6 @@ module.exports = (app) => {
     app.use("/applications/company", router);
 
     /**
-     * Approves a Pending Company Application
-     */
-    router.get("/",
-        authMiddleware.authRequired,
-        authMiddleware.isAdmin,
-        async (req, res, next) => {
-
-            try {
-                const applications = await (new ApplicationService()).findAll();
-                return res.json(applications);
-            } catch (err) {
-                return next(err);
-            }
-        });
-
-
-    /**
      * Searches for a Company Application, with provided filters
      */
     router.get("/search", companyApplicationValidators.search, async (req, res, next) => {

--- a/src/api/routes/review.js
+++ b/src/api/routes/review.js
@@ -57,12 +57,10 @@ module.exports = (app) => {
                     return res
                         .status(HTTPStatus.NOT_FOUND)
                         .json(buildErrorResponse(ErrorTypes.VALIDATION_ERROR, [err.message]));
-                } else if (err instanceof ApplicationService.CompanyApplicationAlreadyReiewed) {
-                    return res
-                        .status(HTTPStatus.CONFLICT)
-                        .json(buildErrorResponse(ErrorTypes.VALIDATION_ERROR, [err.message]));
-
-                } else if (err instanceof ApplicationService.CompanyApplicationEmailAlreadyInUse) {
+                } else if (
+                    err instanceof ApplicationService.CompanyApplicationAlreadyReiewed ||
+                    err instanceof ApplicationService.CompanyApplicationEmailAlreadyInUse
+                ) {
                     return res
                         .status(HTTPStatus.CONFLICT)
                         .json(buildErrorResponse(ErrorTypes.VALIDATION_ERROR, [err.message]));

--- a/src/models/Account.js
+++ b/src/models/Account.js
@@ -22,7 +22,8 @@ const AccountSchema = new Schema({
         },
     },
     company: {
-        type: Schema.Types.ObjectId, ref: "Company",
+        type: Schema.Types.ObjectId,
+        ref: "Company",
         required: function() {
             return !this.isAdmin;
         },
@@ -46,4 +47,5 @@ AccountSchema.methods.validatePassword = async function(password) {
 };
 
 const Account = mongoose.model("Account", AccountSchema);
+
 module.exports = Account;

--- a/src/models/Company.js
+++ b/src/models/Company.js
@@ -12,7 +12,6 @@ const CompanySchema = new Schema({
     contacts: {
         type: Map,
         of: String,
-        required: true,
         validate: [
             (val) => val.size >= 1,
             "There must be at least one contact",
@@ -21,7 +20,6 @@ const CompanySchema = new Schema({
     bio: {
         type: String,
         maxlength: CompanyConstants.bio.max_length,
-        required: true,
     },
 });
 

--- a/src/models/CompanyApplication.js
+++ b/src/models/CompanyApplication.js
@@ -172,6 +172,9 @@ CompanyApplicationSchema.methods.undoApproval = function() {
     return this.save({ validateModifiedOnly: true });
 };
 
+// Creating an index to make fetching faster
+CompanyApplicationSchema.index({ submittedAt: 1 });
+
 const CompanyApplication = mongoose.model("CompanyApplication", CompanyApplicationSchema);
 module.exports = CompanyApplication;
 module.exports.applicationUniqueness = applicationUniqueness;

--- a/src/models/CompanyApplication.js
+++ b/src/models/CompanyApplication.js
@@ -131,9 +131,7 @@ async function validateSingleActiveApplication(value) {
     return true;
 }
 
-const isApprovable = async (id) => {
-    const application = await CompanyApplication.findById(id).exec();
-    if (!application) throw new Error(CompanyApplicationRules.MUST_EXIST_TO_APPROVE.msg);
+const isApprovable = (application) => {
 
     if (application.state !== ApplicationStatus.PENDING)
         throw new Error(CompanyApplicationRules.CANNOT_REVIEW_TWICE.msg);
@@ -141,9 +139,7 @@ const isApprovable = async (id) => {
     return true;
 };
 
-const isRejectable = async (id) => {
-    const application = await CompanyApplication.findById(id).exec();
-    if (!application) throw new Error(CompanyApplicationRules.MUST_EXIST_TO_REJECT.msg);
+const isRejectable = (application) => {
 
     if (application.state !== ApplicationStatus.PENDING)
         throw new Error(CompanyApplicationRules.CANNOT_REVIEW_TWICE.msg);
@@ -152,6 +148,7 @@ const isRejectable = async (id) => {
 };
 
 CompanyApplicationSchema.methods.approve = function() {
+    isApprovable(this);
     this.approvedAt = Date.now();
     // Need to prevent validation, otherwise it will fail the email uniqueness,
     // Since there is already an application with same email: itself :)
@@ -159,6 +156,7 @@ CompanyApplicationSchema.methods.approve = function() {
 };
 
 CompanyApplicationSchema.methods.reject = function(reason) {
+    isRejectable(this);
     this.rejectedAt = Date.now();
     this.rejectReason = reason;
     // Need to prevent validation, otherwise it will fail the email uniqueness,

--- a/src/models/CompanyApplication.js
+++ b/src/models/CompanyApplication.js
@@ -81,6 +81,8 @@ const CompanyApplicationSchema = new Schema({
     },
 });
 
+CompanyApplicationSchema.index({ companyName: "text" });
+
 CompanyApplicationSchema.virtual("state").get(function() {
     if (!this.approvedAt && !this.rejectedAt) return ApplicationStatus.PENDING;
     else if (this.approvedAt) return ApplicationStatus.APPROVED;

--- a/src/models/CompanyApplication.js
+++ b/src/models/CompanyApplication.js
@@ -153,14 +153,23 @@ CompanyApplicationSchema.methods.approve = function() {
     this.approvedAt = Date.now();
     // Need to prevent validation, otherwise it will fail the email uniqueness,
     // Since there is already an application with same email: itself :)
-    return this.save({ validateBeforeSave: false });
+    return this.save({ validateModifiedOnly: true });
 };
 
-CompanyApplicationSchema.methods.reject = function() {
+CompanyApplicationSchema.methods.reject = function(reason) {
     this.rejectedAt = Date.now();
+    this.rejectReason = reason;
     // Need to prevent validation, otherwise it will fail the email uniqueness,
     // Since there is already an application with same email: itself :)
-    return this.save({ validateBeforeSave: false });
+    return this.save({ validateModifiedOnly: true });
+};
+
+CompanyApplicationSchema.methods.undoApproval = function() {
+    if (!this.approvedAt) throw new Error("Cannot undo approval of yet-to-be approved Company Application");
+    this.approvedAt = undefined;
+    // Need to prevent validation, otherwise it will fail the email uniqueness,
+    // Since there is already an application with same email: itself :)
+    return this.save({ validateModifiedOnly: true });
 };
 
 const CompanyApplication = mongoose.model("CompanyApplication", CompanyApplicationSchema);

--- a/src/models/CompanyApplication.js
+++ b/src/models/CompanyApplication.js
@@ -34,7 +34,7 @@ const CompanyApplicationRules = Object.freeze({
     },
 });
 
-const CompanyApplicationSchema = new Schema({
+const CompanyApplicationProps = {
     email: {
         type: String,
         trim: true,
@@ -79,7 +79,9 @@ const CompanyApplicationSchema = new Schema({
             return !!this.rejectedAt;
         },
     },
-});
+};
+
+const CompanyApplicationSchema = new Schema(CompanyApplicationProps);
 
 CompanyApplicationSchema.index({ companyName: "text" });
 
@@ -181,3 +183,4 @@ module.exports.applicationUniqueness = applicationUniqueness;
 module.exports.isApprovable = isApprovable;
 module.exports.isRejectable = isRejectable;
 module.exports.CompanyApplicationRules = CompanyApplicationRules;
+module.exports.CompanyApplicationProps = CompanyApplicationProps;

--- a/src/models/CompanyApplication.js
+++ b/src/models/CompanyApplication.js
@@ -177,6 +177,14 @@ CompanyApplicationSchema.methods.undoApproval = function() {
 // Creating an index to make fetching faster
 CompanyApplicationSchema.index({ submittedAt: 1 });
 
+// Include virtuals and remove password field in toObject calls
+CompanyApplicationSchema.set("toJSON", { getters: true });
+CompanyApplicationSchema.set("toObject", { transform: (obj) => {
+    // eslint-disable-next-line no-unused-vars
+    const { password, ...trimmedDoc } = obj.toJSON();
+    return { ...trimmedDoc };
+} });
+
 const CompanyApplication = mongoose.model("CompanyApplication", CompanyApplicationSchema);
 module.exports = CompanyApplication;
 module.exports.applicationUniqueness = applicationUniqueness;

--- a/src/services/account.js
+++ b/src/services/account.js
@@ -1,7 +1,7 @@
 const Account = require("../models/Account");
 const hash = require("../lib/passwordHashing");
 const Company = require("../models/Company");
-class AuthService {
+class AccountService {
     // TODO: Use typedi or similar
     constructor() {
 
@@ -36,4 +36,4 @@ class AuthService {
     }
 }
 
-module.exports = AuthService;
+module.exports = AccountService;

--- a/src/services/application.js
+++ b/src/services/application.js
@@ -18,6 +18,28 @@ class CompanyApplicationService {
         delete retVal.password;
         return retVal;
     }
+
+    findById(id) {
+        return CompanyApplication.findById(id).exec();
+    }
+
+    async findAll() {
+        return Promise.all([...(await CompanyApplication.find({}).exec())]
+            .map(async (application) => ({
+                ...application.toObject(),
+                state: (await CompanyApplication.findById(application._id).exec()).state,
+            })));
+    }
+
+    async approve(id) {
+        const application = await CompanyApplication.findById(id);
+        return application.approve();
+    }
+
+    async reject(id) {
+        const application = await CompanyApplication.findById(id);
+        return application.reject();
+    }
 }
 
 module.exports = CompanyApplicationService;

--- a/src/services/application.js
+++ b/src/services/application.js
@@ -1,5 +1,6 @@
 const CompanyApplication = require("../models/CompanyApplication");
 const hash = require("../lib/passwordHashing");
+const AccountService = require("./account");
 
 class CompanyApplicationService {
 
@@ -32,13 +33,23 @@ class CompanyApplicationService {
     }
 
     async approve(id, options) {
-        const application = await CompanyApplication.findById(id, {}, options);
-        return application.approve();
+
+        const application = (await CompanyApplication.findById(id, {}, options));
+        application.approve();
+        try {
+            const account = await (new AccountService()).registerCompany(application.email, application.password, application.companyName);
+            return { application, account };
+
+        } catch (err) {
+            console.error(`Error creating account for approved Company Application, rolling back approval of ${application._id}`);
+            application.undoApproval();
+            throw err;
+        }
     }
 
-    async reject(id, options) {
+    async reject(id, reason, options) {
         const application = await CompanyApplication.findById(id, {}, options);
-        return application.reject();
+        return application.reject(reason);
     }
 }
 

--- a/src/services/application.js
+++ b/src/services/application.js
@@ -63,6 +63,18 @@ class CompanyApplicationService {
         return filterQueries;
     }
 
+    /**
+     *
+     * @param {*} filters - object with optional properties: state, submissionDate, companyName
+     * {
+     *      companyName: String
+     *      submissionDate: { - only one of the properties is necessary, but you can use both to define interval
+     *          from: Date
+     *          to: Date
+     *      }
+     *      state: String | Array - String for exact match, Array to provide set of options
+     * }
+     */
     async find(filters) {
 
         const { state: stateFilter, ...queryFilters } = { ...filters };
@@ -70,9 +82,10 @@ class CompanyApplicationService {
 
         return (await Promise.all(
             (await CompanyApplication.find(
-                queryFilters.length ? {
+                Object.keys(queryFilters).length ? {
                     $and: this.buildFiltersQuery(queryFilters),
                 } : {})
+                .sort({ submittedAt: "desc" })
                 .exec()
             )
                 .map(async (application) => ({

--- a/src/services/application.js
+++ b/src/services/application.js
@@ -65,7 +65,7 @@ class CompanyApplicationService {
 
     async find(filters) {
 
-        const { state: stateFilter, ...queryFilters } = filters;
+        const { state: stateFilter, ...queryFilters } = { ...filters };
         if (!filters || Object.keys(filters).length === 0) return this.findAll();
 
         return (await Promise.all(

--- a/src/services/application.js
+++ b/src/services/application.js
@@ -31,13 +31,13 @@ class CompanyApplicationService {
             })));
     }
 
-    async approve(id) {
-        const application = await CompanyApplication.findById(id);
+    async approve(id, options) {
+        const application = await CompanyApplication.findById(id, {}, options);
         return application.approve();
     }
 
-    async reject(id) {
-        const application = await CompanyApplication.findById(id);
+    async reject(id, options) {
+        const application = await CompanyApplication.findById(id, {}, options);
         return application.reject();
     }
 }

--- a/src/services/auth.js
+++ b/src/services/auth.js
@@ -1,12 +1,13 @@
 const Account = require("../models/Account");
 const hash = require("../lib/passwordHashing");
+const Company = require("../models/Company");
 class AuthService {
     // TODO: Use typedi or similar
     constructor() {
 
     }
 
-    async register(email, password) {
+    async registerAdmin(email, password) {
         const account = await Account.create({
             email,
             password: await hash(password),
@@ -15,6 +16,22 @@ class AuthService {
 
         return {
             email: account.email,
+        };
+    }
+
+    async registerCompany(email, password, companyName) {
+
+        const company = await Company.create({ name: companyName });
+
+        const account = await Account.create({
+            email,
+            password,
+            company,
+        });
+
+        return {
+            email: account.email,
+            companyName: account.company.name,
         };
     }
 }

--- a/test/company_schema.js
+++ b/test/company_schema.js
@@ -8,8 +8,6 @@ describe("# Company Schema tests", () => {
     describe("Required and bound (min and max) properties tests", () => {
         describe("required using schema 'required' property (no user defined validators)", () => {
             CompanySchemaTester.fieldRequired("name");
-            CompanySchemaTester.fieldRequired("contacts");
-            CompanySchemaTester.fieldRequired("bio");
         });
 
         describe("Required to respect a certain length", () => {

--- a/test/end-to-end/review.js
+++ b/test/end-to-end/review.js
@@ -1,8 +1,11 @@
 const HTTPStatus = require("http-status-codes");
 const CompanyApplication = require("../../src/models/CompanyApplication");
+const CompanyApplicationRules = require("../../src/models/CompanyApplication").CompanyApplicationRules;
 const { APPROVED, PENDING } = require("../../src/models/constants/ApplicationStatus");
 const hash = require("../../src/lib/passwordHashing");
 const Account = require("../../src/models/Account");
+const { ErrorTypes } = require("../../src/api/middleware/errorHandler");
+const ApplicationStatus = require("../../src/models/constants/ApplicationStatus");
 const { ObjectId } = require("mongoose").Types;
 
 describe("Company application review endpoint test", () => {
@@ -18,7 +21,7 @@ describe("Company application review endpoint test", () => {
                 .get("/applications/company/search");
 
             expect(emptyRes.status).toBe(HTTPStatus.OK);
-            expect(emptyRes.body).toEqual([]);
+            expect(emptyRes.body.applications).toEqual([]);
 
             const application = {
                 email: "test2@test.com",
@@ -36,8 +39,8 @@ describe("Company application review endpoint test", () => {
                 .get("/applications/company/search");
 
             expect(nonEmptyRes.status).toBe(HTTPStatus.OK);
-            expect(nonEmptyRes.body.length).toBe(1);
-            expect(nonEmptyRes.body[0]).toHaveProperty("email", application.email);
+            expect(nonEmptyRes.body.applications.length).toBe(1);
+            expect(nonEmptyRes.body.applications[0]).toHaveProperty("email", application.email);
 
         });
 
@@ -82,18 +85,18 @@ describe("Company application review endpoint test", () => {
                     .send({ filters: { companyName: "approved Testing company" } });
 
                 expect(fullNameQuery.status).toBe(HTTPStatus.OK);
-                expect(fullNameQuery.body.length).toBe(1);
-                expect(fullNameQuery.body[0]).toHaveProperty("companyName", approvedApplication.companyName);
+                expect(fullNameQuery.body.applications.length).toBe(1);
+                expect(fullNameQuery.body.applications[0]).toHaveProperty("companyName", approvedApplication.companyName);
 
                 const partialNameQuery = await request()
                     .get("/applications/company/search")
                     .send({ filters: { companyName: "Testing company" } });
 
                 expect(partialNameQuery.status).toBe(HTTPStatus.OK);
-                expect(partialNameQuery.body.length).toBe(3);
-                expect(partialNameQuery.body[0]).toHaveProperty("companyName", pendingApplication.companyName);
-                expect(partialNameQuery.body[1]).toHaveProperty("companyName", approvedApplication.companyName);
-                expect(partialNameQuery.body[2]).toHaveProperty("companyName", rejectedApplication.companyName);
+                expect(partialNameQuery.body.applications.length).toBe(3);
+                expect(partialNameQuery.body.applications[0]).toHaveProperty("companyName", pendingApplication.companyName);
+                expect(partialNameQuery.body.applications[1]).toHaveProperty("companyName", approvedApplication.companyName);
+                expect(partialNameQuery.body.applications[2]).toHaveProperty("companyName", rejectedApplication.companyName);
             });
 
             test("Should filter by state", async () => {
@@ -102,17 +105,17 @@ describe("Company application review endpoint test", () => {
                     .send({ filters: { state: APPROVED } });
 
                 expect(singleStateQuery.status).toBe(HTTPStatus.OK);
-                expect(singleStateQuery.body.length).toBe(1);
-                expect(singleStateQuery.body[0]).toHaveProperty("companyName", approvedApplication.companyName);
+                expect(singleStateQuery.body.applications.length).toBe(1);
+                expect(singleStateQuery.body.applications[0]).toHaveProperty("companyName", approvedApplication.companyName);
 
                 const multiStateQuery = await request()
                     .get("/applications/company/search")
                     .send({ filters: { state: [APPROVED, PENDING] } });
 
                 expect(multiStateQuery.status).toBe(HTTPStatus.OK);
-                expect(multiStateQuery.body.length).toBe(2);
-                expect(multiStateQuery.body[0]).toHaveProperty("companyName", pendingApplication.companyName);
-                expect(multiStateQuery.body[1]).toHaveProperty("companyName", approvedApplication.companyName);
+                expect(multiStateQuery.body.applications.length).toBe(2);
+                expect(multiStateQuery.body.applications[0]).toHaveProperty("companyName", pendingApplication.companyName);
+                expect(multiStateQuery.body.applications[1]).toHaveProperty("companyName", approvedApplication.companyName);
             });
 
             test("Should filter by date", async () => {
@@ -122,18 +125,18 @@ describe("Company application review endpoint test", () => {
                     .send({ filters: { submissionDate: { from: approvedApplication.submittedAt } } });
 
                 expect(afterQuery.status).toBe(HTTPStatus.OK);
-                expect(afterQuery.body.length).toBe(2);
-                expect(afterQuery.body[0]).toHaveProperty("companyName", pendingApplication.companyName);
-                expect(afterQuery.body[1]).toHaveProperty("companyName", approvedApplication.companyName);
+                expect(afterQuery.body.applications.length).toBe(2);
+                expect(afterQuery.body.applications[0]).toHaveProperty("companyName", pendingApplication.companyName);
+                expect(afterQuery.body.applications[1]).toHaveProperty("companyName", approvedApplication.companyName);
 
                 const untilQuery = await request()
                     .get("/applications/company/search")
                     .send({ filters: { submissionDate: { to: approvedApplication.submittedAt } } });
 
                 expect(untilQuery.status).toBe(HTTPStatus.OK);
-                expect(untilQuery.body.length).toBe(2);
-                expect(untilQuery.body[0]).toHaveProperty("companyName", approvedApplication.companyName);
-                expect(untilQuery.body[1]).toHaveProperty("companyName", rejectedApplication.companyName);
+                expect(untilQuery.body.applications.length).toBe(2);
+                expect(untilQuery.body.applications[0]).toHaveProperty("companyName", approvedApplication.companyName);
+                expect(untilQuery.body.applications[1]).toHaveProperty("companyName", rejectedApplication.companyName);
 
                 const intervalQuery = await request()
                     .get("/applications/company/search")
@@ -147,9 +150,95 @@ describe("Company application review endpoint test", () => {
                     });
 
                 expect(intervalQuery.status).toBe(HTTPStatus.OK);
-                expect(intervalQuery.body.length).toBe(1);
-                expect(intervalQuery.body[0]).toHaveProperty("companyName", approvedApplication.companyName);
+                expect(intervalQuery.body.applications.length).toBe(1);
+                expect(intervalQuery.body.applications[0]).toHaveProperty("companyName", approvedApplication.companyName);
 
+            });
+
+        });
+
+        describe("Sort application results", () => {
+
+            const pendingApplication = {
+                email: "test2@test.com",
+                password: "password123",
+                companyName: "testing company",
+                motivation: "This company has a very valid motivation, because otherwise the tests would not exist.",
+                submittedAt: new Date("2019-11-25"),
+            };
+
+            const approvedApplication = {
+                ...pendingApplication,
+                submittedAt: new Date("2019-11-24"),
+                approvedAt: pendingApplication.submittedAt.getTime() + 1,
+                companyName: "approved Testing company",
+                email: `approved${pendingApplication.email}`,
+            };
+            const rejectedApplication = { ...pendingApplication,
+                submittedAt: new Date("2019-11-23"),
+                rejectedAt: pendingApplication.submittedAt.getTime() + 1,
+                companyName: "rejected Testing company",
+                email: `rejected${pendingApplication.email}`,
+                rejectReason: "2bad4nij0bs",
+            };
+
+            beforeEach(async () => {
+                await CompanyApplication.create(pendingApplication);
+                await CompanyApplication.create(approvedApplication);
+                await CompanyApplication.create(rejectedApplication);
+            });
+
+            afterEach(async () => {
+                await CompanyApplication.deleteMany({});
+            });
+
+            test("Should sort by company name ascending", async () => {
+                const query = await request()
+                    .get("/applications/company/search")
+                    .send({ sortBy: { companyName: "asc" } });
+
+
+                expect(query.status).toBe(HTTPStatus.OK);
+                expect(query.body.applications.length).toBe(3);
+                expect(query.body.applications[0]).toHaveProperty("companyName", approvedApplication.companyName);
+                expect(query.body.applications[1]).toHaveProperty("companyName", rejectedApplication.companyName);
+                expect(query.body.applications[2]).toHaveProperty("companyName", pendingApplication.companyName);
+            });
+
+            test("Should sort by company name descending", async () => {
+                const query = await request()
+                    .get("/applications/company/search")
+                    .send({ sortBy: { companyName: "desc" } });
+
+
+                expect(query.status).toBe(HTTPStatus.OK);
+                expect(query.body.applications.length).toBe(3);
+                expect(query.body.applications[0]).toHaveProperty("companyName", pendingApplication.companyName);
+                expect(query.body.applications[1]).toHaveProperty("companyName", rejectedApplication.companyName);
+                expect(query.body.applications[2]).toHaveProperty("companyName", approvedApplication.companyName);
+            });
+
+            test("Should sort by submissionDate descending", async () => {
+                const defaultQuery = await request()
+                    .get("/applications/company/search")
+                    .send();
+
+
+                expect(defaultQuery.status).toBe(HTTPStatus.OK);
+                expect(defaultQuery.body.applications.length).toBe(3);
+                expect(defaultQuery.body.applications[0]).toHaveProperty("companyName", pendingApplication.companyName);
+                expect(defaultQuery.body.applications[1]).toHaveProperty("companyName", approvedApplication.companyName);
+                expect(defaultQuery.body.applications[2]).toHaveProperty("companyName", rejectedApplication.companyName);
+
+                const query = await request()
+                    .get("/applications/company/search")
+                    .send({ sortBy: { submittedAt: "desc" } });
+
+                expect(query.status).toBe(HTTPStatus.OK);
+                expect(query.body.applications.length).toBe(3);
+                expect(query.body.applications[0]).toHaveProperty("companyName", pendingApplication.companyName);
+                expect(query.body.applications[1]).toHaveProperty("companyName", approvedApplication.companyName);
+                expect(query.body.applications[2]).toHaveProperty("companyName", rejectedApplication.companyName);
             });
 
         });
@@ -230,6 +319,20 @@ describe("Company application review endpoint test", () => {
                         .post(`/applications/company/${application._id}/approve`);
 
                     expect(res.status).toBe(HTTPStatus.CONFLICT);
+                });
+
+                test("Should fail if approving application with an existing account with same email, and then rollback", async () => {
+                    await Account.create({ email: application.email, password: "passwordHashedButNotReally", isAdmin: true });
+
+                    const res = await test_agent
+                        .post(`/applications/company/${application._id}/approve`);
+
+                    expect(res.status).toBe(HTTPStatus.CONFLICT);
+                    expect(res.body.error_code).toBe(ErrorTypes.VALIDATION_ERROR);
+                    expect(res.body.errors[0]).toBe(CompanyApplicationRules.EMAIL_ALREADY_IN_USE.msg);
+
+                    const result_application = await CompanyApplication.findById(application._id);
+                    expect(result_application.state).toBe(ApplicationStatus.PENDING);
                 });
             });
 

--- a/test/end-to-end/review.js
+++ b/test/end-to-end/review.js
@@ -12,393 +12,409 @@ describe("Company application review endpoint test", () => {
 
     describe("/applications/company", () => {
 
-        beforeEach(async () => {
-            await CompanyApplication.deleteMany({});
-        });
-
-        test("Should list existing applications", async () => {
-            const emptyRes = await request()
-                .get("/applications/company/search");
-
-            expect(emptyRes.status).toBe(HTTPStatus.OK);
-            expect(emptyRes.body.applications).toEqual([]);
-
-            const application = {
-                email: "test2@test.com",
-                password: "password123",
-                companyName: "Testing company",
-                motivation: "This company has a very valid motivation, because otherwise the tests would not exist.",
-            };
-
-            await CompanyApplication.create({
-                ...application,
-                submittedAt: Date.now(),
-            });
-
-            const nonEmptyRes = await request()
-                .get("/applications/company/search");
-
-            expect(nonEmptyRes.status).toBe(HTTPStatus.OK);
-            expect(nonEmptyRes.body.applications.length).toBe(1);
-            expect(nonEmptyRes.body.applications[0]).toHaveProperty("email", application.email);
-
-        });
-
-        describe("Filter application results", () => {
-
-            const pendingApplication = {
-                email: "test2@test.com",
-                password: "password123",
-                companyName: "Testing company",
-                motivation: "This company has a very valid motivation, because otherwise the tests would not exist.",
-                submittedAt: new Date("2019-11-25"),
-            };
-
-            const approvedApplication = {
-                ...pendingApplication,
-                submittedAt: new Date("2019-11-24"),
-                approvedAt: pendingApplication.submittedAt.getTime() + 1,
-                companyName: "approved Testing company",
-                email: `approved${pendingApplication.email}`,
-            };
-            const rejectedApplication = { ...pendingApplication,
-                submittedAt: new Date("2019-11-23"),
-                rejectedAt: pendingApplication.submittedAt.getTime() + 1,
-                companyName: "rejected Testing company",
-                email: `rejected${pendingApplication.email}`,
-                rejectReason: "2bad4nij0bs",
-            };
-
+        describe("Without Auth", () => {
             beforeEach(async () => {
-                await CompanyApplication.create(pendingApplication);
-                await CompanyApplication.create(approvedApplication);
-                await CompanyApplication.create(rejectedApplication);
-            });
-
-            afterEach(async () => {
                 await CompanyApplication.deleteMany({});
             });
 
-            test("Should filter by company name", async () => {
-                const fullNameQuery = await request()
-                    .get("/applications/company/search")
-                    .send({ filters: { companyName: "approved Testing company" } });
+            test("Should return HTTP 401 error", async () => {
+                const emptyRes = await request()
+                    .get("/applications/company/search");
 
-                expect(fullNameQuery.status).toBe(HTTPStatus.OK);
-                expect(fullNameQuery.body.applications.length).toBe(1);
-                expect(fullNameQuery.body.applications[0]).toHaveProperty("companyName", approvedApplication.companyName);
-
-                const partialNameQuery = await request()
-                    .get("/applications/company/search")
-                    .send({ filters: { companyName: "Testing company" } });
-
-                expect(partialNameQuery.status).toBe(HTTPStatus.OK);
-                expect(partialNameQuery.body.applications.length).toBe(3);
-                expect(partialNameQuery.body.applications[0]).toHaveProperty("companyName", pendingApplication.companyName);
-                expect(partialNameQuery.body.applications[1]).toHaveProperty("companyName", approvedApplication.companyName);
-                expect(partialNameQuery.body.applications[2]).toHaveProperty("companyName", rejectedApplication.companyName);
-            });
-
-            test("Should filter by state", async () => {
-                const singleStateQuery = await request()
-                    .get("/applications/company/search")
-                    .send({ filters: { state: APPROVED } });
-
-                expect(singleStateQuery.status).toBe(HTTPStatus.OK);
-                expect(singleStateQuery.body.applications.length).toBe(1);
-                expect(singleStateQuery.body.applications[0]).toHaveProperty("companyName", approvedApplication.companyName);
-
-                const multiStateQuery = await request()
-                    .get("/applications/company/search")
-                    .send({ filters: { state: [APPROVED, PENDING] } });
-
-                expect(multiStateQuery.status).toBe(HTTPStatus.OK);
-                expect(multiStateQuery.body.applications.length).toBe(2);
-                expect(multiStateQuery.body.applications[0]).toHaveProperty("companyName", pendingApplication.companyName);
-                expect(multiStateQuery.body.applications[1]).toHaveProperty("companyName", approvedApplication.companyName);
-            });
-
-            test("Should filter by date", async () => {
-
-                const afterQuery = await request()
-                    .get("/applications/company/search")
-                    .send({ filters: { submissionDate: { from: approvedApplication.submittedAt } } });
-
-                expect(afterQuery.status).toBe(HTTPStatus.OK);
-                expect(afterQuery.body.applications.length).toBe(2);
-                expect(afterQuery.body.applications[0]).toHaveProperty("companyName", pendingApplication.companyName);
-                expect(afterQuery.body.applications[1]).toHaveProperty("companyName", approvedApplication.companyName);
-
-                const untilQuery = await request()
-                    .get("/applications/company/search")
-                    .send({ filters: { submissionDate: { to: approvedApplication.submittedAt } } });
-
-                expect(untilQuery.status).toBe(HTTPStatus.OK);
-                expect(untilQuery.body.applications.length).toBe(2);
-                expect(untilQuery.body.applications[0]).toHaveProperty("companyName", approvedApplication.companyName);
-                expect(untilQuery.body.applications[1]).toHaveProperty("companyName", rejectedApplication.companyName);
-
-                const intervalQuery = await request()
-                    .get("/applications/company/search")
-                    .send({
-                        filters: {
-                            submissionDate: {
-                                from: approvedApplication.submittedAt,
-                                to: approvedApplication.submittedAt,
-                            },
-                        },
-                    });
-
-                expect(intervalQuery.status).toBe(HTTPStatus.OK);
-                expect(intervalQuery.body.applications.length).toBe(1);
-                expect(intervalQuery.body.applications[0]).toHaveProperty("companyName", approvedApplication.companyName);
-
+                expect(emptyRes.status).toBe(HTTPStatus.UNAUTHORIZED);
             });
 
         });
 
-        describe("Sort application results", () => {
-
-            const pendingApplication = {
-                email: "test2@test.com",
-                password: "password123",
-                companyName: "testing company",
-                motivation: "This company has a very valid motivation, because otherwise the tests would not exist.",
-                submittedAt: new Date("2019-11-25"),
-            };
-
-            const approvedApplication = {
-                ...pendingApplication,
-                submittedAt: new Date("2019-11-24"),
-                approvedAt: pendingApplication.submittedAt.getTime() + 1,
-                companyName: "approved Testing company",
-                email: `approved${pendingApplication.email}`,
-            };
-            const rejectedApplication = { ...pendingApplication,
-                submittedAt: new Date("2019-11-23"),
-                rejectedAt: pendingApplication.submittedAt.getTime() + 1,
-                companyName: "rejected Testing company",
-                email: `rejected${pendingApplication.email}`,
-                rejectReason: "2bad4nij0bs",
-            };
-
-            beforeEach(async () => {
-                await CompanyApplication.create(pendingApplication);
-                await CompanyApplication.create(approvedApplication);
-                await CompanyApplication.create(rejectedApplication);
-            });
-
-            afterEach(async () => {
-                await CompanyApplication.deleteMany({});
-            });
-
-            test("Should sort by company name ascending", async () => {
-                const query = await request()
-                    .get("/applications/company/search")
-                    .send({ sortBy: { companyName: "asc" } });
-
-
-                expect(query.status).toBe(HTTPStatus.OK);
-                expect(query.body.applications.length).toBe(3);
-                expect(query.body.applications[0]).toHaveProperty("companyName", approvedApplication.companyName);
-                expect(query.body.applications[1]).toHaveProperty("companyName", rejectedApplication.companyName);
-                expect(query.body.applications[2]).toHaveProperty("companyName", pendingApplication.companyName);
-            });
-
-            test("Should sort by company name descending", async () => {
-                const query = await request()
-                    .get("/applications/company/search")
-                    .send({ sortBy: { companyName: "desc" } });
-
-
-                expect(query.status).toBe(HTTPStatus.OK);
-                expect(query.body.applications.length).toBe(3);
-                expect(query.body.applications[0]).toHaveProperty("companyName", pendingApplication.companyName);
-                expect(query.body.applications[1]).toHaveProperty("companyName", rejectedApplication.companyName);
-                expect(query.body.applications[2]).toHaveProperty("companyName", approvedApplication.companyName);
-            });
-
-            test("Should sort by submissionDate descending", async () => {
-                const defaultQuery = await request()
-                    .get("/applications/company/search")
-                    .send();
-
-
-                expect(defaultQuery.status).toBe(HTTPStatus.OK);
-                expect(defaultQuery.body.applications.length).toBe(3);
-                expect(defaultQuery.body.applications[0]).toHaveProperty("companyName", pendingApplication.companyName);
-                expect(defaultQuery.body.applications[1]).toHaveProperty("companyName", approvedApplication.companyName);
-                expect(defaultQuery.body.applications[2]).toHaveProperty("companyName", rejectedApplication.companyName);
-
-                const query = await request()
-                    .get("/applications/company/search")
-                    .send({ sortBy: { submittedAt: "desc" } });
-
-                expect(query.status).toBe(HTTPStatus.OK);
-                expect(query.body.applications.length).toBe(3);
-                expect(query.body.applications[0]).toHaveProperty("companyName", pendingApplication.companyName);
-                expect(query.body.applications[1]).toHaveProperty("companyName", approvedApplication.companyName);
-                expect(query.body.applications[2]).toHaveProperty("companyName", rejectedApplication.companyName);
-            });
-
-        });
-
-        describe("Approval/Rejection", () => {
-            let application;
-            const pendingApplication = {
-                email: "test2@test.com",
-                password: "password123",
-                companyName: "Testing company",
-                motivation: "This company has a very valid motivation, because otherwise the tests would not exist.",
-                submittedAt: new Date("2019-11-25"),
-            };
-
+        describe("With Auth", () => {
             const test_agent = agent();
             const test_user = {
                 email: "user@email.com",
                 password: "password123",
             };
 
-            describe("Approve application", () => {
+            beforeAll(async () => {
+                await Account.deleteMany({});
+                await Account.create({ email: test_user.email, password: await hash(test_user.password), isAdmin: true });
 
-                beforeAll(async () => {
-                    await Account.deleteMany({});
-                    await Account.create({ email: test_user.email, password: await hash(test_user.password), isAdmin: true });
-
-                    // Login
-                    await test_agent
-                        .post("/auth/login")
-                        .send(test_user)
-                        .expect(200);
-                });
-
-                beforeEach(async () => {
-                    await Account.deleteMany({ email: pendingApplication.email });
-                    application = await CompanyApplication.create(pendingApplication);
-                });
-
-                afterEach(async () => {
-                    await CompanyApplication.deleteMany({});
-                });
-
-                test("Should approve pending application", async () => {
-
-                    const res = await test_agent
-                        .post(`/applications/company/${application._id}/approve`);
-
-                    expect(res.status).toBe(HTTPStatus.OK);
-                    expect(res.body.email).toBe(pendingApplication.email);
-                    expect(res.body.companyName).toBe(pendingApplication.companyName);
-                });
-
-                test("Should fail if trying to approve inexistent application", async () => {
-
-                    const res = await test_agent
-                        .post(`/applications/company/${new ObjectId()}/approve`);
-
-                    expect(res.status).toBe(HTTPStatus.CONFLICT);
-                });
-
-                test("Should fail if trying to approve already approved application", async () => {
-                    await test_agent
-                        .post(`/applications/company/${application._id}/approve`);
-
-                    const res = await test_agent
-                        .post(`/applications/company/${application._id}/approve`);
-
-                    expect(res.status).toBe(HTTPStatus.CONFLICT);
-                });
-
-                test("Should fail if trying to approve already rejected application", async () => {
-                    await test_agent
-                        .post(`/applications/company/${application._id}/reject`)
-                        .send({ rejectReason: "Some reason which is valid" });
-
-
-                    const res = await test_agent
-                        .post(`/applications/company/${application._id}/approve`);
-
-                    expect(res.status).toBe(HTTPStatus.CONFLICT);
-                });
-
-                test("Should fail if approving application with an existing account with same email, and then rollback", async () => {
-                    await Account.create({ email: application.email, password: "passwordHashedButNotReally", isAdmin: true });
-
-                    const res = await test_agent
-                        .post(`/applications/company/${application._id}/approve`);
-
-                    expect(res.status).toBe(HTTPStatus.CONFLICT);
-                    expect(res.body.error_code).toBe(ErrorTypes.VALIDATION_ERROR);
-                    expect(res.body.errors[0]).toBe(CompanyApplicationRules.EMAIL_ALREADY_IN_USE.msg);
-
-                    const result_application = await CompanyApplication.findById(application._id);
-                    expect(result_application.state).toBe(ApplicationStatus.PENDING);
-                });
+                // Login
+                await test_agent
+                    .post("/auth/login")
+                    .send(test_user)
+                    .expect(200);
             });
 
-            describe("Reject application", () => {
+            beforeEach(async () => {
+                await CompanyApplication.deleteMany({});
+            });
+
+            test("Should list existing applications", async () => {
+                const emptyRes = await test_agent
+                    .get("/applications/company/search");
+
+                expect(emptyRes.status).toBe(HTTPStatus.OK);
+                expect(emptyRes.body.applications).toEqual([]);
+
+                const application = {
+                    email: "test2@test.com",
+                    password: "password123",
+                    companyName: "Testing company",
+                    motivation: "This company has a very valid motivation, because otherwise the tests would not exist.",
+                };
+
+                await CompanyApplication.create({
+                    ...application,
+                    submittedAt: Date.now(),
+                });
+
+                const nonEmptyRes = await test_agent
+                    .get("/applications/company/search");
+
+                expect(nonEmptyRes.status).toBe(HTTPStatus.OK);
+                expect(nonEmptyRes.body.applications.length).toBe(1);
+                expect(nonEmptyRes.body.applications[0]).toHaveProperty("email", application.email);
+
+            });
+
+            describe("Filter application results", () => {
+
+                const pendingApplication = {
+                    email: "test2@test.com",
+                    password: "password123",
+                    companyName: "Testing company",
+                    motivation: "This company has a very valid motivation, because otherwise the tests would not exist.",
+                    submittedAt: new Date("2019-11-25"),
+                };
+
+                const approvedApplication = {
+                    ...pendingApplication,
+                    submittedAt: new Date("2019-11-24"),
+                    approvedAt: pendingApplication.submittedAt.getTime() + 1,
+                    companyName: "approved Testing company",
+                    email: `approved${pendingApplication.email}`,
+                };
+                const rejectedApplication = { ...pendingApplication,
+                    submittedAt: new Date("2019-11-23"),
+                    rejectedAt: pendingApplication.submittedAt.getTime() + 1,
+                    companyName: "rejected Testing company",
+                    email: `rejected${pendingApplication.email}`,
+                    rejectReason: "2bad4nij0bs",
+                };
 
                 beforeEach(async () => {
-                    await Account.deleteMany({ email: pendingApplication.email });
-                    application = await CompanyApplication.create(pendingApplication);
+                    await CompanyApplication.create(pendingApplication);
+                    await CompanyApplication.create(approvedApplication);
+                    await CompanyApplication.create(rejectedApplication);
                 });
 
                 afterEach(async () => {
                     await CompanyApplication.deleteMany({});
                 });
 
-                test("Should fail if no rejectReason provided", async () => {
-                    const res = await test_agent
-                        .post(`/applications/company/${application._id}/reject`);
+                test("Should filter by company name", async () => {
+                    const fullNameQuery = await test_agent
+                        .get("/applications/company/search")
+                        .send({ filters: { companyName: "approved Testing company" } });
 
-                    expect(res.status).toBe(HTTPStatus.UNPROCESSABLE_ENTITY);
-                    expect(res.body.errors[0]).toStrictEqual({ location: "body", msg: "required", param: "rejectReason" });
+                    expect(fullNameQuery.status).toBe(HTTPStatus.OK);
+                    expect(fullNameQuery.body.applications.length).toBe(1);
+                    expect(fullNameQuery.body.applications[0]).toHaveProperty("companyName", approvedApplication.companyName);
+
+                    const partialNameQuery = await test_agent
+                        .get("/applications/company/search")
+                        .send({ filters: { companyName: "Testing company" } });
+
+                    expect(partialNameQuery.status).toBe(HTTPStatus.OK);
+                    expect(partialNameQuery.body.applications.length).toBe(3);
+                    expect(partialNameQuery.body.applications[0]).toHaveProperty("companyName", pendingApplication.companyName);
+                    expect(partialNameQuery.body.applications[1]).toHaveProperty("companyName", approvedApplication.companyName);
+                    expect(partialNameQuery.body.applications[2]).toHaveProperty("companyName", rejectedApplication.companyName);
+                });
+
+                test("Should filter by state", async () => {
+                    const singleStateQuery = await test_agent
+                        .get("/applications/company/search")
+                        .send({ filters: { state: APPROVED } });
+
+                    expect(singleStateQuery.status).toBe(HTTPStatus.OK);
+                    expect(singleStateQuery.body.applications.length).toBe(1);
+                    expect(singleStateQuery.body.applications[0]).toHaveProperty("companyName", approvedApplication.companyName);
+
+                    const multiStateQuery = await test_agent
+                        .get("/applications/company/search")
+                        .send({ filters: { state: [APPROVED, PENDING] } });
+
+                    expect(multiStateQuery.status).toBe(HTTPStatus.OK);
+                    expect(multiStateQuery.body.applications.length).toBe(2);
+                    expect(multiStateQuery.body.applications[0]).toHaveProperty("companyName", pendingApplication.companyName);
+                    expect(multiStateQuery.body.applications[1]).toHaveProperty("companyName", approvedApplication.companyName);
+                });
+
+                test("Should filter by date", async () => {
+
+                    const afterQuery = await test_agent
+                        .get("/applications/company/search")
+                        .send({ filters: { submissionDate: { from: approvedApplication.submittedAt } } });
+
+                    expect(afterQuery.status).toBe(HTTPStatus.OK);
+                    expect(afterQuery.body.applications.length).toBe(2);
+                    expect(afterQuery.body.applications[0]).toHaveProperty("companyName", pendingApplication.companyName);
+                    expect(afterQuery.body.applications[1]).toHaveProperty("companyName", approvedApplication.companyName);
+
+                    const untilQuery = await test_agent
+                        .get("/applications/company/search")
+                        .send({ filters: { submissionDate: { to: approvedApplication.submittedAt } } });
+
+                    expect(untilQuery.status).toBe(HTTPStatus.OK);
+                    expect(untilQuery.body.applications.length).toBe(2);
+                    expect(untilQuery.body.applications[0]).toHaveProperty("companyName", approvedApplication.companyName);
+                    expect(untilQuery.body.applications[1]).toHaveProperty("companyName", rejectedApplication.companyName);
+
+                    const intervalQuery = await test_agent
+                        .get("/applications/company/search")
+                        .send({
+                            filters: {
+                                submissionDate: {
+                                    from: approvedApplication.submittedAt,
+                                    to: approvedApplication.submittedAt,
+                                },
+                            },
+                        });
+
+                    expect(intervalQuery.status).toBe(HTTPStatus.OK);
+                    expect(intervalQuery.body.applications.length).toBe(1);
+                    expect(intervalQuery.body.applications[0]).toHaveProperty("companyName", approvedApplication.companyName);
 
                 });
 
-                test("Should reject pending application", async () => {
-                    const res = await test_agent
-                        .post(`/applications/company/${application._id}/reject`)
-                        .send({ rejectReason: "Some reason which is valid" });
+            });
 
-                    expect(res.status).toBe(HTTPStatus.OK);
-                    expect(res.body.email).toBe(pendingApplication.email);
-                    expect(res.body.companyName).toBe(pendingApplication.companyName);
+            describe("Sort application results", () => {
+
+                const pendingApplication = {
+                    email: "test2@test.com",
+                    password: "password123",
+                    companyName: "testing company",
+                    motivation: "This company has a very valid motivation, because otherwise the tests would not exist.",
+                    submittedAt: new Date("2019-11-25"),
+                };
+
+                const approvedApplication = {
+                    ...pendingApplication,
+                    submittedAt: new Date("2019-11-24"),
+                    approvedAt: pendingApplication.submittedAt.getTime() + 1,
+                    companyName: "approved Testing company",
+                    email: `approved${pendingApplication.email}`,
+                };
+                const rejectedApplication = { ...pendingApplication,
+                    submittedAt: new Date("2019-11-23"),
+                    rejectedAt: pendingApplication.submittedAt.getTime() + 1,
+                    companyName: "rejected Testing company",
+                    email: `rejected${pendingApplication.email}`,
+                    rejectReason: "2bad4nij0bs",
+                };
+
+                beforeEach(async () => {
+                    await CompanyApplication.create(pendingApplication);
+                    await CompanyApplication.create(approvedApplication);
+                    await CompanyApplication.create(rejectedApplication);
                 });
 
-                test("Should fail if trying to reject inexistent application", async () => {
-                    const res = await test_agent
-                        .post(`/applications/company/${new ObjectId()}/reject`)
-                        .send({ rejectReason: "Some reason which is valid" });
-
-                    expect(res.status).toBe(HTTPStatus.CONFLICT);
+                afterEach(async () => {
+                    await CompanyApplication.deleteMany({});
                 });
 
-                test("Should fail if trying to reject already approved application", async () => {
-                    await test_agent
-                        .post(`/applications/company/${application._id}/approve`);
+                test("Should sort by company name ascending", async () => {
+                    const query = await test_agent
+                        .get("/applications/company/search")
+                        .send({ sortBy: { companyName: "asc" } });
 
-                    const res = await test_agent
-                        .post(`/applications/company/${application._id}/reject`)
-                        .send({ rejectReason: "Some reason which is valid" });
 
-                    expect(res.status).toBe(HTTPStatus.CONFLICT);
+                    expect(query.status).toBe(HTTPStatus.OK);
+                    expect(query.body.applications.length).toBe(3);
+                    expect(query.body.applications[0]).toHaveProperty("companyName", approvedApplication.companyName);
+                    expect(query.body.applications[1]).toHaveProperty("companyName", rejectedApplication.companyName);
+                    expect(query.body.applications[2]).toHaveProperty("companyName", pendingApplication.companyName);
                 });
 
-                test("Should fail if trying to reject already rejected application", async () => {
-                    await test_agent
-                        .post(`/applications/company/${application._id}/reject`)
-                        .send({ rejectReason: "Some reason which is valid" });
+                test("Should sort by company name descending", async () => {
+                    const query = await test_agent
+                        .get("/applications/company/search")
+                        .send({ sortBy: { companyName: "desc" } });
 
-                    const res = await test_agent
-                        .post(`/applications/company/${application._id}/reject`)
-                        .send({ rejectReason: "Some reason which is valid" });
 
-                    expect(res.status).toBe(HTTPStatus.CONFLICT);
+                    expect(query.status).toBe(HTTPStatus.OK);
+                    expect(query.body.applications.length).toBe(3);
+                    expect(query.body.applications[0]).toHaveProperty("companyName", pendingApplication.companyName);
+                    expect(query.body.applications[1]).toHaveProperty("companyName", rejectedApplication.companyName);
+                    expect(query.body.applications[2]).toHaveProperty("companyName", approvedApplication.companyName);
+                });
+
+                test("Should sort by submissionDate descending", async () => {
+                    const defaultQuery = await test_agent
+                        .get("/applications/company/search")
+                        .send();
+
+
+                    expect(defaultQuery.status).toBe(HTTPStatus.OK);
+                    expect(defaultQuery.body.applications.length).toBe(3);
+                    expect(defaultQuery.body.applications[0]).toHaveProperty("companyName", pendingApplication.companyName);
+                    expect(defaultQuery.body.applications[1]).toHaveProperty("companyName", approvedApplication.companyName);
+                    expect(defaultQuery.body.applications[2]).toHaveProperty("companyName", rejectedApplication.companyName);
+
+                    const query = await test_agent
+                        .get("/applications/company/search")
+                        .send({ sortBy: { submittedAt: "desc" } });
+
+                    expect(query.status).toBe(HTTPStatus.OK);
+                    expect(query.body.applications.length).toBe(3);
+                    expect(query.body.applications[0]).toHaveProperty("companyName", pendingApplication.companyName);
+                    expect(query.body.applications[1]).toHaveProperty("companyName", approvedApplication.companyName);
+                    expect(query.body.applications[2]).toHaveProperty("companyName", rejectedApplication.companyName);
+                });
+
+            });
+
+            describe("Approval/Rejection", () => {
+                let application;
+                const pendingApplication = {
+                    email: "test2@test.com",
+                    password: "password123",
+                    companyName: "Testing company",
+                    motivation: "This company has a very valid motivation, because otherwise the tests would not exist.",
+                    submittedAt: new Date("2019-11-25"),
+                };
+
+
+                describe("Approve application", () => {
+
+
+                    beforeEach(async () => {
+                        await Account.deleteMany({ email: pendingApplication.email });
+                        application = await CompanyApplication.create(pendingApplication);
+                    });
+
+                    afterEach(async () => {
+                        await CompanyApplication.deleteMany({});
+                    });
+
+                    test("Should approve pending application", async () => {
+
+                        const res = await test_agent
+                            .post(`/applications/company/${application._id}/approve`);
+
+                        expect(res.status).toBe(HTTPStatus.OK);
+                        expect(res.body.email).toBe(pendingApplication.email);
+                        expect(res.body.companyName).toBe(pendingApplication.companyName);
+                    });
+
+                    test("Should fail if trying to approve inexistent application", async () => {
+
+                        const res = await test_agent
+                            .post(`/applications/company/${new ObjectId()}/approve`);
+
+                        expect(res.status).toBe(HTTPStatus.CONFLICT);
+                    });
+
+                    test("Should fail if trying to approve already approved application", async () => {
+                        await test_agent
+                            .post(`/applications/company/${application._id}/approve`);
+
+                        const res = await test_agent
+                            .post(`/applications/company/${application._id}/approve`);
+
+                        expect(res.status).toBe(HTTPStatus.CONFLICT);
+                    });
+
+                    test("Should fail if trying to approve already rejected application", async () => {
+                        await test_agent
+                            .post(`/applications/company/${application._id}/reject`)
+                            .send({ rejectReason: "Some reason which is valid" });
+
+
+                        const res = await test_agent
+                            .post(`/applications/company/${application._id}/approve`);
+
+                        expect(res.status).toBe(HTTPStatus.CONFLICT);
+                    });
+
+                    test("Should fail if approving application with an existing account with same email, and then rollback", async () => {
+                        await Account.create({ email: application.email, password: "passwordHashedButNotReally", isAdmin: true });
+
+                        const res = await test_agent
+                            .post(`/applications/company/${application._id}/approve`);
+
+                        expect(res.status).toBe(HTTPStatus.CONFLICT);
+                        expect(res.body.error_code).toBe(ErrorTypes.VALIDATION_ERROR);
+                        expect(res.body.errors[0]).toBe(CompanyApplicationRules.EMAIL_ALREADY_IN_USE.msg);
+
+                        const result_application = await CompanyApplication.findById(application._id);
+                        expect(result_application.state).toBe(ApplicationStatus.PENDING);
+                    });
+                });
+
+                describe("Reject application", () => {
+
+                    beforeEach(async () => {
+                        await Account.deleteMany({ email: pendingApplication.email });
+                        application = await CompanyApplication.create(pendingApplication);
+                    });
+
+                    afterEach(async () => {
+                        await CompanyApplication.deleteMany({});
+                    });
+
+                    test("Should fail if no rejectReason provided", async () => {
+                        const res = await test_agent
+                            .post(`/applications/company/${application._id}/reject`);
+
+                        expect(res.status).toBe(HTTPStatus.UNPROCESSABLE_ENTITY);
+                        expect(res.body.errors[0]).toStrictEqual({ location: "body", msg: "required", param: "rejectReason" });
+
+                    });
+
+                    test("Should reject pending application", async () => {
+                        const res = await test_agent
+                            .post(`/applications/company/${application._id}/reject`)
+                            .send({ rejectReason: "Some reason which is valid" });
+
+                        expect(res.status).toBe(HTTPStatus.OK);
+                        expect(res.body.email).toBe(pendingApplication.email);
+                        expect(res.body.companyName).toBe(pendingApplication.companyName);
+                    });
+
+                    test("Should fail if trying to reject inexistent application", async () => {
+                        const res = await test_agent
+                            .post(`/applications/company/${new ObjectId()}/reject`)
+                            .send({ rejectReason: "Some reason which is valid" });
+
+                        expect(res.status).toBe(HTTPStatus.CONFLICT);
+                    });
+
+                    test("Should fail if trying to reject already approved application", async () => {
+                        await test_agent
+                            .post(`/applications/company/${application._id}/approve`);
+
+                        const res = await test_agent
+                            .post(`/applications/company/${application._id}/reject`)
+                            .send({ rejectReason: "Some reason which is valid" });
+
+                        expect(res.status).toBe(HTTPStatus.CONFLICT);
+                    });
+
+                    test("Should fail if trying to reject already rejected application", async () => {
+                        await test_agent
+                            .post(`/applications/company/${application._id}/reject`)
+                            .send({ rejectReason: "Some reason which is valid" });
+
+                        const res = await test_agent
+                            .post(`/applications/company/${application._id}/reject`)
+                            .send({ rejectReason: "Some reason which is valid" });
+
+                        expect(res.status).toBe(HTTPStatus.CONFLICT);
+                    });
                 });
             });
         });
-
-
     });
 });

--- a/test/end-to-end/review.js
+++ b/test/end-to-end/review.js
@@ -1,11 +1,12 @@
 const HTTPStatus = require("http-status-codes");
 const CompanyApplication = require("../../src/models/CompanyApplication");
+const { APPROVED, PENDING } = require("../../src/models/constants/ApplicationStatus");
 
 describe("Company application review endpoint test", () => {
 
     describe("/applications/company", () => {
 
-        beforeAll(async () => {
+        beforeEach(async () => {
             await CompanyApplication.deleteMany({});
         });
 
@@ -37,8 +38,62 @@ describe("Company application review endpoint test", () => {
 
         });
 
-        test("Should filter application results", async () => {
-            // TODO
+        describe("Filter application results", () => {
+
+            const pendingApplication = {
+                email: "test2@test.com",
+                password: "password123",
+                companyName: "Testing company",
+                motivation: "This company has a very valid motivation, because otherwise the tests would not exist.",
+                submittedAt: Date.now(),
+            };
+
+            const approvedApplication = {
+                ...pendingApplication,
+                approvedAt: Date.now() + 1,
+                companyName: "approved Testing company",
+                email: `approved${pendingApplication.email}`,
+            };
+            const rejectedApplication = { ...pendingApplication,
+                rejectedAt: Date.now() + 1,
+                companyName: "rejected Testing company",
+                email: `rejected${pendingApplication.email}`,
+                rejectReason: "2bad4nij0bs",
+            };
+
+            beforeEach(async () => {
+                await CompanyApplication.create(pendingApplication);
+                await CompanyApplication.create(approvedApplication);
+                await CompanyApplication.create(rejectedApplication);
+            });
+
+            afterEach(async () => {
+                await CompanyApplication.deleteMany({});
+            });
+
+            test("Should filter by state", async () => {
+                const singleStateQuery = await request()
+                    .get("/applications/company/search")
+                    .send({ filters: { state: APPROVED } });
+
+                expect(singleStateQuery.status).toBe(HTTPStatus.OK);
+                expect(singleStateQuery.body.length).toBe(1);
+                expect(singleStateQuery.body[0]).toHaveProperty("companyName", approvedApplication.companyName);
+
+                const multiStateQuery = await request()
+                    .get("/applications/company/search")
+                    .send({ filters: { state: [APPROVED, PENDING] } });
+
+                expect(multiStateQuery.status).toBe(HTTPStatus.OK);
+                expect(multiStateQuery.body.length).toBe(2);
+                expect(multiStateQuery.body[0]).toHaveProperty("companyName", pendingApplication.companyName);
+                expect(multiStateQuery.body[1]).toHaveProperty("companyName", approvedApplication.companyName);
+            });
+
+            test("Should filter by date", async () => {
+
+            });
+
         });
     });
 });

--- a/test/end-to-end/review.js
+++ b/test/end-to-end/review.js
@@ -1,0 +1,44 @@
+const HTTPStatus = require("http-status-codes");
+const CompanyApplication = require("../../src/models/CompanyApplication");
+
+describe("Company application review endpoint test", () => {
+
+    describe("/applications/company", () => {
+
+        beforeAll(async () => {
+            await CompanyApplication.deleteMany({});
+        });
+
+        test("Should list existing applications", async () => {
+            const emptyRes = await request()
+                .get("/applications/company/search");
+
+            expect(emptyRes.status).toBe(HTTPStatus.OK);
+            expect(emptyRes.body).toEqual([]);
+
+            const application = {
+                email: "test2@test.com",
+                password: "password123",
+                companyName: "Testing company",
+                motivation: "This company has a very valid motivation, because otherwise the tests would not exist.",
+            };
+
+            await CompanyApplication.create({
+                ...application,
+                submittedAt: Date.now(),
+            });
+
+            const nonEmptyRes = await request()
+                .get("/applications/company/search");
+
+            expect(nonEmptyRes.status).toBe(HTTPStatus.OK);
+            expect(nonEmptyRes.body.length).toBe(1);
+            expect(nonEmptyRes.body[0]).toHaveProperty("email", application.email);
+
+        });
+
+        test("Should filter application results", async () => {
+            // TODO
+        });
+    });
+});


### PR DESCRIPTION
Addresses missing functionality on #54 

Added 
* GET `/applications/company/search` - list all applications, applying provided filters and with pagination
    * limit: number
    * offset: number
    * filters
    ```js
        companyName: String
        submissionDate: { - only one of the properties is necessary, but you can use both to define interval
            from: Date
            to: Date
        }
        state: String | Array - String for exact match, Array to provide set of options
    ```

* POST `/applications/company/:id/approve` (approves company application with id=:id)
* POST `/applications/company/:id/reject` (rejects company application with id=:id)