### PR TITLE
Add extra info on /auth/me request

### DIFF
--- a/src/api/routes/auth.js
+++ b/src/api/routes/auth.js
@@ -5,6 +5,7 @@ const passport = require("passport");
 const { authRequired, isGod } = require("../middleware/auth");
 const validators = require("../middleware/validators/auth");
 const AccountService = require("../../services/account");
+const Company = require("../../models/constants/Company");
 
 
 const router = Router();
@@ -13,12 +14,23 @@ module.exports = (app) => {
     app.use("/auth", router);
 
     // Get logged in user info
-    router.get("/me", authRequired, (req, res) => {
-        const userInfo = req.user;
+    router.get("/me", authRequired, async (req, res) => {
+        const { email, isAdmin, company: companyId } = req.user;
+
+        let company = undefined;
+
+        try {
+            if (companyId)
+                company = await Company.findById(companyId);
+        } catch (e) {
+            console.error(`Could not find the respective company of user ${req.user._id}, with id ${companyId}`, e);
+        }
+
         return res.status(HTTPStatus.OK).json({
             data: {
-                _id: userInfo._id,
-                email: userInfo.email,
+                email,
+                isAdmin,
+                company
             },
         });
     });

--- a/test/end-to-end/auth.js
+++ b/test/end-to-end/auth.js
@@ -147,6 +147,8 @@ describe("Login endpoint test", () => {
 
             expect(res.status).toBe(HTTPStatus.OK);
             expect(res.body).toHaveProperty("data.email", test_user.email);
+            expect(res.body).toHaveProperty("data.isAdmin", true);
+            expect(res.body).not.toHaveProperty("data.company");
         });
 
         test("should be successful when loging out the current user", async () => {


### PR DESCRIPTION
`isAdmin` field is needed to customize the UI on some pages and even restrict others. I also added `company` information when available, in order to show the company name on the user menu, for example