### PR TITLE
Add owner auto-fill when creating offers

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "prod": "NODE_ENV=production node src/index.js",
     "lint": "eslint src test --max-warnings 0",
     "lint-fix": "npm run lint -- --fix",
-    "test": "NODE_ENV=test jest --runInBand",
+    "test": "NODE_ENV=test jest --runInBand --coverage --verbose false",
     "ci": "npm run lint && npm test",
     "audit": "npm audit --audit-level=high --json | npm-audit-helper"
   },

--- a/src/api/middleware/auth.js
+++ b/src/api/middleware/auth.js
@@ -25,6 +25,12 @@ const isGod = (req, res, next) => {
     return next();
 };
 
+const isCompanyOrGod = (req, res, next) => {
+    if (req?.user?.company) return next();
+
+    return isGod(req, res, next);
+};
+
 const isAdmin = (req, res, next) => {
     if (!req.user.isAdmin) {
         return res.status(HTTPStatus.UNAUTHORIZED).json({
@@ -40,4 +46,5 @@ module.exports = {
     authRequired,
     isGod,
     isAdmin,
+    isCompanyOrGod,
 };

--- a/src/api/middleware/auth.js
+++ b/src/api/middleware/auth.js
@@ -15,6 +15,12 @@ const authRequired = (req, res, next) => {
 
 // Eventually should be done via a session in an god account, but at least this will work for now, before a permission system is added
 const isGod = (req, res, next) => {
+    if (!req.body.god_token) {
+        return res.status(HTTPStatus.UNAUTHORIZED).json({
+            reason: "Insufficient Permissions",
+            error_code: ErrorTypes.FORBIDDEN,
+        });
+    }
     if (req.body.god_token !== config.god_token) {
         return res.status(HTTPStatus.UNAUTHORIZED).json({
             reason: "Invalid god token",

--- a/src/api/middleware/validators/offer.js
+++ b/src/api/middleware/validators/offer.js
@@ -98,21 +98,16 @@ const create = useExpressValidators([
         .optional()
         .isBoolean().withMessage(ValidationReasons.BOOLEAN),
 
-    // TODO: Add validation for the owner being a Mongo ObjectId that is correctly referencing an existing Company
     body("owner", ValidationReasons.DEFAULT)
         .custom(async (owner, { req }) => {
 
             // When it reaches this validation, the user is either company or god
-            if (req?.user?.company) {
-                return true;
-            }
+            if (req?.user?.company) return true;
 
-            if (!owner) {
-                throw new Error(ValidationReasons.REQUIRED);
-            }
+            if (!owner) throw new Error(ValidationReasons.REQUIRED);
 
             try {
-                await Company.findById(owner);
+                if (await Company.findById(owner) === null) throw new Error("Company not found");
             } catch (e) {
                 throw new Error(`no-company-found-with-id-${owner}`);
             }

--- a/src/api/middleware/validators/offer.js
+++ b/src/api/middleware/validators/offer.js
@@ -107,15 +107,15 @@ const create = useExpressValidators([
             if (!owner) throw new Error(ValidationReasons.REQUIRED);
 
             try {
-                if (await Company.findById(owner) === null) throw new Error("Company not found");
-            } catch (e) {
-                throw new Error(`no-company-found-with-id-${owner}`);
+                if (await Company.findById(owner) === null) throw new Error();
+            } catch (_e) {
+                // Also catches any fail to the DB
+                throw new Error(ValidationReasons.COMPANY_NOT_FOUND(owner));
             }
 
             // Returning truthy value to indicate no error ocurred
             return true;
-        })
-        .withMessage("no-company-found-with-id-"),
+        }),
 
     body("location", ValidationReasons.DEFAULT)
         .exists().withMessage(ValidationReasons.REQUIRED).bail()

--- a/src/api/middleware/validators/validationReasons.js
+++ b/src/api/middleware/validators/validationReasons.js
@@ -18,7 +18,8 @@ const ValidationReasons = Object.freeze({
     ALREADY_EXISTS: (variable) => `${variable}-already-exists`,
     DATE_EXPIRED: "date-already-past",
     MUST_BE_AFTER: (variable) => `must-be-after:${variable}`,
-    WRONG_FORMAT: (format) => `must-be-format-${format}`
+    WRONG_FORMAT: (format) => `must-be-format-${format}`,
+    COMPANY_NOT_FOUND: (id) => `no-company-found-with-id:${id}`
 });
 
 module.exports = ValidationReasons;

--- a/src/api/routes/auth.js
+++ b/src/api/routes/auth.js
@@ -5,7 +5,7 @@ const passport = require("passport");
 const { authRequired, isGod } = require("../middleware/auth");
 const validators = require("../middleware/validators/auth");
 const AccountService = require("../../services/account");
-const Company = require("../../models/constants/Company");
+const Company = require("../../models/Company");
 
 
 const router = Router();

--- a/src/api/routes/offer.js
+++ b/src/api/routes/offer.js
@@ -7,10 +7,11 @@ const OfferService = require("../../services/offer");
 const router = Router();
 
 module.exports = (app) => {
-    app.use("/offer", router);
+    app.use("/offers", router);
 
     /**
      * Gets all currently active offers (without filtering, for now)
+     * supports offset and limit as query params
      */
     router.get("/", validators.get, async (req, res, next) => {
         try {
@@ -25,10 +26,15 @@ module.exports = (app) => {
     /**
      * Creates a new Offer
      */
-    router.post("/", authMiddleware.isGod, validators.create, async (req, res, next) => {
+    router.post("/", authMiddleware.isCompanyOrGod, validators.create, async (req, res, next) => {
         try {
-            // This is safe since the service is destructuring the passed object and the fields have been validated
-            const offer = await (new OfferService()).create(req.body);
+
+            const params = {
+                ...req.body,
+                owner: req.user ? req.user._id : req.body.owner
+            };
+
+            const offer = await (new OfferService()).create(params);
 
             return res.json(offer);
         } catch (err) {

--- a/src/api/routes/offer.js
+++ b/src/api/routes/offer.js
@@ -15,7 +15,12 @@ module.exports = (app) => {
      */
     router.get("/", validators.get, async (req, res, next) => {
         try {
-            const offers = await (new OfferService()).get(req.query);
+            const offers = await (new OfferService()).get(
+                {
+                    ...req.query,
+                    showHidden: req?.query?.showHidden && req?.user?.isAdmin
+                }
+            );
 
             return res.json(offers);
         } catch (err) {

--- a/src/api/routes/offer.js
+++ b/src/api/routes/offer.js
@@ -31,7 +31,7 @@ module.exports = (app) => {
 
             const params = {
                 ...req.body,
-                owner: req.user ? req.user.company : req.body.owner
+                owner: req?.user?.company || req.body.owner
             };
 
             const offer = await (new OfferService()).create(params);

--- a/src/api/routes/offer.js
+++ b/src/api/routes/offer.js
@@ -31,7 +31,7 @@ module.exports = (app) => {
 
             const params = {
                 ...req.body,
-                owner: req.user ? req.user._id : req.body.owner
+                owner: req.user ? req.user.company : req.body.owner
             };
 
             const offer = await (new OfferService()).create(params);

--- a/src/api/routes/offer.js
+++ b/src/api/routes/offer.js
@@ -26,7 +26,7 @@ module.exports = (app) => {
     /**
      * Creates a new Offer
      */
-    router.post("/", authMiddleware.isCompanyOrGod, validators.create, async (req, res, next) => {
+    router.post("/new", authMiddleware.isCompanyOrGod, validators.create, async (req, res, next) => {
         try {
 
             const params = {

--- a/src/models/Company.js
+++ b/src/models/Company.js
@@ -10,12 +10,7 @@ const CompanySchema = new Schema({
         minlength: CompanyConstants.companyName.min_length,
     },
     contacts: {
-        type: Map,
-        of: String,
-        validate: [
-            (val) => val.size >= 1,
-            "There must be at least one contact",
-        ],
+        type: [String],
     },
     bio: {
         type: String,

--- a/src/models/Offer.js
+++ b/src/models/Offer.js
@@ -48,11 +48,10 @@ const OfferSchema = new Schema({
     description: { type: String, maxlength: OfferConstants.description.max_length, required: true },
 
     contacts: {
-        type: Map,
-        of: String,
+        type: [String],
         required: true,
         validate: [
-            (val) => val.size >= 1,
+            (val) => val.length >= 1,
             "There must be at least one contact",
         ],
     },
@@ -71,7 +70,10 @@ const OfferSchema = new Schema({
         validate: (val) => lengthBetweenValidator(val, MIN_TECHNOLOGIES, MAX_TECHNOLOGIES) && noDuplicatesValidator(val),
     },
 
-    isHidden: { type: Boolean },
+    isHidden: {
+        type: Boolean,
+        default: false
+    },
     owner: { type: Types.ObjectId, ref: "Company", required: true },
 
     location: { type: String, required: true },
@@ -108,6 +110,13 @@ OfferSchema.query.current = function() {
             $gt: new Date(Date.now()),
         },
     });
+};
+
+/**
+ * Currently active and non-hidden Offers
+ */
+OfferSchema.query.bright = function() {
+    return this.current().where({ isHidden: false });
 };
 
 const Offer = mongoose.model("Offer", OfferSchema);

--- a/src/models/Offer.js
+++ b/src/models/Offer.js
@@ -124,8 +124,8 @@ OfferSchema.query.current = function() {
 /**
  * Currently active and non-hidden Offers
  */
-OfferSchema.query.bright = function() {
-    return this.current().where({ isHidden: false });
+OfferSchema.query.withoutHidden = function() {
+    return this.where({ isHidden: false });
 };
 
 const Offer = mongoose.model("Offer", OfferSchema);

--- a/src/models/Offer.js
+++ b/src/models/Offer.js
@@ -5,6 +5,7 @@ const JobTypes = require("./constants/JobTypes");
 const { FieldTypes, MIN_FIELDS, MAX_FIELDS } = require("./constants/FieldTypes");
 const { TechnologyTypes, MIN_TECHNOLOGIES, MAX_TECHNOLOGIES } = require("./constants/TechnologyTypes");
 const PointSchema = require("./Point");
+const Company = require("./Company");
 const { MONTH_IN_MS, OFFER_MAX_LIFETIME_MONTHS } = require("./constants/TimeConstants");
 const { noDuplicatesValidator, lengthBetweenValidator } = require("./modelUtils");
 const OfferConstants = require("./constants/Offer");
@@ -79,6 +80,14 @@ const OfferSchema = new Schema({
     location: { type: String, required: true },
     coordinates: { type: PointSchema, required: false },
 });
+
+OfferSchema.methods.withCompany = async function() {
+    const offer = this.toObject();
+
+    const company = await Company.findById(offer.owner);
+
+    return { ...offer, company };
+};
 
 // Checking if the publication date is less than or equal than the end date.
 function validatePublishDate(value) {

--- a/src/models/Offer.js
+++ b/src/models/Offer.js
@@ -52,7 +52,7 @@ const OfferSchema = new Schema({
         required: true,
         validate: [
             (val) => val.length >= 1,
-            "There must be at least one contact",
+            "There must be at least one contact.",
         ],
     },
 

--- a/src/services/offer.js
+++ b/src/services/offer.js
@@ -57,14 +57,14 @@ class OfferService {
         let offers;
 
         if (showHidden) {
-            offers = await Offer.find().current()
-                .skip(offset).limit(limit);
+            offers = (await Offer.find().current()
+                .skip(offset).limit(limit)).map((o) => o.withCompany());
         } else {
-            offers = await Offer.find().bright()
-                .skip(offset).limit(limit);
+            offers = (await Offer.find().bright()
+                .skip(offset).limit(limit)).map((o) => o.withCompany());
         }
 
-        return offers;
+        return Promise.all(offers);
     }
 }
 

--- a/src/services/offer.js
+++ b/src/services/offer.js
@@ -52,9 +52,17 @@ class OfferService {
         return offer;
     }
 
-    async get({ offset = 0, limit = OfferService.MAX_OFFERS_PER_QUERY }) {
-        const offers = await Offer.find().current()
-            .skip(offset).limit(limit);
+    async get({ offset = 0, limit = OfferService.MAX_OFFERS_PER_QUERY, showHidden = false }) {
+
+        let offers;
+
+        if (showHidden) {
+            offers = await Offer.find().current()
+                .skip(offset).limit(limit);
+        } else {
+            offers = await Offer.find().bright()
+                .skip(offset).limit(limit);
+        }
 
         return offers;
     }

--- a/src/services/offer.js
+++ b/src/services/offer.js
@@ -54,17 +54,15 @@ class OfferService {
 
     async get({ offset = 0, limit = OfferService.MAX_OFFERS_PER_QUERY, showHidden = false }) {
 
-        let offers;
+        const offers = Offer.find().current();
 
-        if (showHidden) {
-            offers = (await Offer.find().current()
-                .skip(offset).limit(limit)).map((o) => o.withCompany());
-        } else {
-            offers = (await Offer.find().bright()
-                .skip(offset).limit(limit)).map((o) => o.withCompany());
-        }
+        if (!showHidden) offers.withoutHidden();
 
-        return Promise.all(offers);
+        return Promise.all((await offers
+            .skip(offset)
+            .limit(limit)
+        ).map((o) => o.withCompany()));
+
     }
 }
 

--- a/test/company_schema.js
+++ b/test/company_schema.js
@@ -15,36 +15,5 @@ describe("# Company Schema tests", () => {
             CompanySchemaTester.minLength("name", CompanyConstants.companyName.min_length);
             CompanySchemaTester.maxLength("name", CompanyConstants.companyName.max_length);
         });
-
-        describe("required using custom validators (checking for array lengths, etc)", () => {
-            describe("There must be at least one contact", () => {
-                test("No contacts throws error", () => {
-                    const test_contacts = new Map();
-
-                    const company = new Company({
-                        contacts: test_contacts,
-                    });
-
-                    return company.validate((err) => {
-                        expect(err.errors.contacts).toBeDefined();
-                        expect(err.errors.contacts).toHaveProperty("kind", "user defined");
-                        expect(err.errors.contacts).toHaveProperty("message", "There must be at least one contact");
-                    });
-                });
-
-                test("At least 1 contact does not throw error", () => {
-                    const company = new Company({
-                        contacts: {
-                            email: "legitcontact@company.com",
-                        },
-                    });
-
-                    return company.validate((err) => {
-                        expect(err.errors.contacts).toBeFalsy();
-                    });
-                });
-
-            });
-        });
     });
 });

--- a/test/end-to-end/offer.js
+++ b/test/end-to-end/offer.js
@@ -348,9 +348,42 @@ describe("Offer endpoint tests", () => {
         describe("Using already created offer(s)", () => {
             describe("Only current offers are returned", () => {
 
-                let test_offer;
-                let expired_test_offer;
-                let future_test_offer;
+                const test_offer = {
+                    title: "Test Offer",
+                    publishDate: "2019-11-22T00:00:00.000Z",
+                    publishEndDate: "2019-11-28T00:00:00.000Z",
+                    description: "For Testing Purposes",
+                    contacts: ["geral@niaefeup.pt", "229417766"],
+                    jobType: "SUMMER INTERNSHIP",
+                    fields: ["DEVOPS", "MACHINE LEARNING", "OTHER"],
+                    technologies: ["React", "CSS"],
+                    // owner: Will be set in beforeAll,
+                    location: "Testing Street, Test City, 123",
+                };
+                const expired_test_offer = {
+                    title: "Expired Test Offer",
+                    publishDate: "2019-11-17",
+                    publishEndDate: "2019-11-18",
+                    description: "For Testing Purposes",
+                    contacts: ["geral@niaefeup.pt", "229417766"],
+                    jobType: "SUMMER INTERNSHIP",
+                    fields: ["DEVOPS", "MACHINE LEARNING", "OTHER"],
+                    technologies: ["React", "CSS"],
+                    // owner: Will be set in beforeAll,
+                    location: "Testing Street, Test City, 123",
+                };
+                const future_test_offer = {
+                    title: "Future Test Offer",
+                    publishDate: "2019-12-12",
+                    publishEndDate: "2019-12-22",
+                    description: "For Testing Purposes",
+                    contacts: ["geral@niaefeup.pt", "229417766"],
+                    jobType: "SUMMER INTERNSHIP",
+                    fields: ["DEVOPS", "MACHINE LEARNING", "OTHER"],
+                    technologies: ["React", "CSS"],
+                    // owner: Will be set in beforeAll,
+                    location: "Testing Street, Test City, 123",
+                };
                 let test_company;
 
                 beforeAll(async () => {
@@ -362,44 +395,10 @@ describe("Offer endpoint tests", () => {
                         contacts: ["a contact"]
                     });
 
-                    test_offer = {
-                        title: "Test Offer",
-                        publishDate: "2019-11-22T00:00:00.000Z",
-                        publishEndDate: "2019-11-28T00:00:00.000Z",
-                        description: "For Testing Purposes",
-                        contacts: ["geral@niaefeup.pt", "229417766"],
-                        jobType: "SUMMER INTERNSHIP",
-                        fields: ["DEVOPS", "MACHINE LEARNING", "OTHER"],
-                        technologies: ["React", "CSS"],
-                        owner: test_company._id,
-                        location: "Testing Street, Test City, 123",
-                    };
-
-                    expired_test_offer = {
-                        title: "Expired Test Offer",
-                        publishDate: "2019-11-17",
-                        publishEndDate: "2019-11-18",
-                        description: "For Testing Purposes",
-                        contacts: ["geral@niaefeup.pt", "229417766"],
-                        jobType: "SUMMER INTERNSHIP",
-                        fields: ["DEVOPS", "MACHINE LEARNING", "OTHER"],
-                        technologies: ["React", "CSS"],
-                        owner: test_company._id,
-                        location: "Testing Street, Test City, 123",
-                    };
-
-                    future_test_offer = {
-                        title: "Future Test Offer",
-                        publishDate: "2019-12-12",
-                        publishEndDate: "2019-12-22",
-                        description: "For Testing Purposes",
-                        contacts: ["geral@niaefeup.pt", "229417766"],
-                        jobType: "SUMMER INTERNSHIP",
-                        fields: ["DEVOPS", "MACHINE LEARNING", "OTHER"],
-                        technologies: ["React", "CSS"],
-                        owner: test_company._id,
-                        location: "Testing Street, Test City, 123",
-                    };
+                    [test_offer, future_test_offer, expired_test_offer]
+                        .forEach((offer) => {
+                            offer.owner = test_company._id;
+                        });
 
                     await Offer.deleteMany({});
                     await Offer.create([test_offer, expired_test_offer, future_test_offer]);
@@ -441,35 +440,40 @@ describe("Offer endpoint tests", () => {
                     expect(extracted_data).toContainEqual(prepared_test_offer);
                 });
 
-                test("Only `limit` number of offers are returned", async () => {
-
-                    // Add 2 more offers
-                    await Offer.create([test_offer, test_offer]);
-
-                    const res = await request()
-                        .get("/offers")
-                        .query({
-                            limit: 2,
-                        });
-
-                    expect(res.status).toBe(HTTPStatus.OK);
-                    expect(res.body).toHaveLength(2);
-
-                    // Necessary because jest matchers appear to not be working (expect.any(Number), expect.anthing(), etc)
-                    const extracted_data = res.body.map((elem) => {
-                        delete elem["_id"]; delete elem["__v"]; delete elem["owner"];
-                        return elem;
+                describe("When a limit is given", () => {
+                    beforeAll(async () => {
+                        // Add 2 more offers
+                        await Offer.create([test_offer, test_offer]);
                     });
 
-                    const prepared_test_offer = {
-                        ...test_offer,
-                        isHidden: false,
-                        company: JSON.parse(JSON.stringify(test_company.toObject()))
-                    };
+                    test("Only `limit` number of offers are returned", async () => {
 
-                    delete prepared_test_offer["owner"];
 
-                    expect(extracted_data).toContainEqual(prepared_test_offer);
+                        const res = await request()
+                            .get("/offers")
+                            .query({
+                                limit: 2,
+                            });
+
+                        expect(res.status).toBe(HTTPStatus.OK);
+                        expect(res.body).toHaveLength(2);
+
+                        // Necessary because jest matchers appear to not be working (expect.any(Number), expect.anthing(), etc)
+                        const extracted_data = res.body.map((elem) => {
+                            delete elem["_id"]; delete elem["__v"]; delete elem["owner"];
+                            return elem;
+                        });
+
+                        const prepared_test_offer = {
+                            ...test_offer,
+                            isHidden: false,
+                            company: JSON.parse(JSON.stringify(test_company.toObject()))
+                        };
+
+                        delete prepared_test_offer["owner"];
+
+                        expect(extracted_data).toContainEqual(prepared_test_offer);
+                    });
                 });
             });
         });

--- a/test/end-to-end/offer.js
+++ b/test/end-to-end/offer.js
@@ -12,6 +12,7 @@ const OfferConstants = require("../../src/models/constants/Offer");
 const Account = require("../../src/models/Account");
 const Company = require("../../src/models/Company");
 const hash = require("../../src/lib/passwordHashing");
+const ValidationReasons = require("../../src/api/middleware/validators/validationReasons");
 
 //----------------------------------------------------------------
 
@@ -103,13 +104,16 @@ describe("Offer endpoint tests", () => {
                         .send(test_user_company)
                         .expect(200);
 
-                    const res = await request()
+                    const res = await test_agent
                         .post("/offers/new")
-                        .send({ ...offer, owner: test_company._id });
+                        .send({ ...offer });
 
-                    expect(res.status).toBe(HTTPStatus.UNAUTHORIZED);
-                    expect(res.body).toHaveProperty("error_code", ErrorTypes.FORBIDDEN);
-                    expect(res.body).toHaveProperty("reason", "Invalid god token");
+                    expect(res.status).toBe(HTTPStatus.OK);
+                    expect(res.body).toHaveProperty("title", offer.title);
+                    expect(res.body).toHaveProperty("description", offer.description);
+                    expect(res.body).toHaveProperty("location", offer.location);
+                    expect(res.body).toHaveProperty("owner", test_company._id.toString());
+                    // TODO: When ownerName is a thing -> expect(res.body).toHaveProperty("ownerName", test_company.name);
                 });
             });
 
@@ -147,7 +151,7 @@ describe("Offer endpoint tests", () => {
                     expect(res.body.errors).toContainEqual({
                         value: "invalidowner",
                         location: "body",
-                        msg: "no-company-found-with-id-invalidowner",
+                        msg: ValidationReasons.COMPANY_NOT_FOUND("invalidowner"),
                         param: "owner",
                     });
 

--- a/test/end-to-end/review.js
+++ b/test/end-to-end/review.js
@@ -256,7 +256,6 @@ describe("Company application review endpoint test", () => {
                     const defaultQuery = await test_agent
                         .get("/applications/company/search");
 
-
                     expect(defaultQuery.status).toBe(HTTPStatus.OK);
                     expect(defaultQuery.body.applications.length).toBe(3);
                     expect(defaultQuery.body.applications[0]).toHaveProperty("companyName", pendingApplication.companyName);

--- a/test/offer_schema.js
+++ b/test/offer_schema.js
@@ -62,8 +62,8 @@ describe("# Offer Schema tests", () => {
                     await offer.validate();
                 } catch (err) {
                     expect(err.errors.contacts).toBeDefined();
-                    expect(err.errors.contacts).toHaveProperty("kind", "required");
-                    expect(err.errors.contacts).toHaveProperty("message", "Path `contacts` is required.");
+                    expect(err.errors.contacts).toHaveProperty("kind", "user defined");
+                    expect(err.errors.contacts).toHaveProperty("message", "There must be at least one contact.");
                 }
             });
 
@@ -213,7 +213,7 @@ describe("# Offer Schema tests", () => {
 
             describe("There must be at least one contact", () => {
                 test("No contacts throws error", async () => {
-                    const test_contacts = new Map();
+                    const test_contacts = [];
 
                     const offer = new Offer({
                         contacts: test_contacts,
@@ -224,13 +224,12 @@ describe("# Offer Schema tests", () => {
                     } catch (err) {
                         expect(err.errors.contacts).toBeDefined();
                         expect(err.errors.contacts).toHaveProperty("kind", "user defined");
-                        expect(err.errors.contacts).toHaveProperty("message", "There must be at least one contact");
+                        expect(err.errors.contacts).toHaveProperty("message", "There must be at least one contact.");
                     }
                 });
 
                 test("At least 1 contact does not throw error", async () => {
-                    const test_contacts = new Map();
-                    test_contacts.set("email", "memes@niaefeup.pt");
+                    const test_contacts = ["contact@niaefeup.pt"];
 
                     const offer = new Offer({
                         contacts: test_contacts,

--- a/test/utils/ValidatorTester.js
+++ b/test/utils/ValidatorTester.js
@@ -1,3 +1,4 @@
+/* istanbul ignore file */
 const HTTPStatus = require("http-status-codes");
 
 const { ErrorTypes } = require("../../src/api/middleware/errorHandler");
@@ -27,12 +28,17 @@ const ValidatorTester = (requestEndpoint) => (location) => (field_name) => ({
             const params = {};
             const res = await requestEndpoint(params);
 
-            checkCommonErrorResponse(res);
-            expect(res.body.errors).toContainEqual({
-                "location": location,
-                "msg": ValidationReasons.REQUIRED,
-                "param": field_name,
-            });
+            try {
+                checkCommonErrorResponse(res);
+
+                expect(res.body.errors).toContainEqual({
+                    "location": location,
+                    "msg": ValidationReasons.REQUIRED,
+                    "param": field_name,
+                });
+            } catch (e) {
+                throw new Error(`Failed isRequired test (${requestEndpoint}, ${location}, ${field_name})\n\n${e}`);
+            }
         });
     },
 
@@ -43,13 +49,17 @@ const ValidatorTester = (requestEndpoint) => (location) => (field_name) => ({
             };
             const res = await requestEndpoint(params);
 
-            checkCommonErrorResponse(res);
-            expect(res.body.errors).toContainEqual({
-                "location": location,
-                "msg": ValidationReasons.STRING,
-                "param": field_name,
-                "value": params[field_name],
-            });
+            try {
+                checkCommonErrorResponse(res);
+                expect(res.body.errors).toContainEqual({
+                    "location": location,
+                    "msg": ValidationReasons.STRING,
+                    "param": field_name,
+                    "value": params[field_name],
+                });
+            } catch (e) {
+                throw new Error(`Failed mustBeString test (${requestEndpoint}, ${location}, ${field_name})\n\n${e}`);
+            }
         });
     },
 
@@ -60,13 +70,17 @@ const ValidatorTester = (requestEndpoint) => (location) => (field_name) => ({
             };
             const res = await requestEndpoint(params);
 
-            checkCommonErrorResponse(res);
-            expect(res.body.errors).toContainEqual({
-                "location": location,
-                "msg": ValidationReasons.DATE,
-                "param": field_name,
-                "value": params[field_name],
-            });
+            try {
+                checkCommonErrorResponse(res);
+                expect(res.body.errors).toContainEqual({
+                    "location": location,
+                    "msg": ValidationReasons.DATE,
+                    "param": field_name,
+                    "value": params[field_name],
+                });
+            } catch (e) {
+                throw new Error(`Failed mustBeDate test (${requestEndpoint}, ${location}, ${field_name})\n\n${e}`);
+            }
         });
     },
 
@@ -77,13 +91,18 @@ const ValidatorTester = (requestEndpoint) => (location) => (field_name) => ({
             };
             const res = await requestEndpoint(params);
 
-            checkCommonErrorResponse(res);
-            expect(res.body.errors).toContainEqual({
-                "location": location,
-                "msg": ValidationReasons.DATE_EXPIRED,
-                "param": field_name,
-                "value": params[field_name],
-            });
+            try {
+
+                checkCommonErrorResponse(res);
+                expect(res.body.errors).toContainEqual({
+                    "location": location,
+                    "msg": ValidationReasons.DATE_EXPIRED,
+                    "param": field_name,
+                    "value": params[field_name],
+                });
+            } catch (e) {
+                throw new Error(`Failed mustBeFuture test (${requestEndpoint}, ${location}, ${field_name})\n\n${e}`);
+            }
         });
     },
 
@@ -96,13 +115,18 @@ const ValidatorTester = (requestEndpoint) => (location) => (field_name) => ({
 
             const res = await requestEndpoint(params);
 
-            checkCommonErrorResponse(res);
-            expect(res.body.errors).toContainEqual({
-                "location": location,
-                "msg": ValidationReasons.MUST_BE_AFTER(field_name2),
-                "param": field_name,
-                "value": params[field_name],
-            });
+            try {
+
+                checkCommonErrorResponse(res);
+                expect(res.body.errors).toContainEqual({
+                    "location": location,
+                    "msg": ValidationReasons.MUST_BE_AFTER(field_name2),
+                    "param": field_name,
+                    "value": params[field_name],
+                });
+            } catch (e) {
+                throw new Error(`Failed mustBeAfter test (${requestEndpoint}, ${location}, ${field_name})\n\n${e}`);
+            }
         });
     },
 
@@ -113,13 +137,17 @@ const ValidatorTester = (requestEndpoint) => (location) => (field_name) => ({
             };
             const res = await requestEndpoint(params);
 
-            checkCommonErrorResponse(res);
-            expect(res.body.errors).toContainEqual({
-                "location": location,
-                "msg": ValidationReasons.INT,
-                "param": field_name,
-                "value": params[field_name],
-            });
+            try {
+                checkCommonErrorResponse(res);
+                expect(res.body.errors).toContainEqual({
+                    "location": location,
+                    "msg": ValidationReasons.INT,
+                    "param": field_name,
+                    "value": params[field_name],
+                });
+            } catch (e) {
+                throw new Error(`Failed mustBeNumber test (${requestEndpoint}, ${location}, ${field_name})\n\n${e}`);
+            }
         });
     },
 
@@ -130,13 +158,17 @@ const ValidatorTester = (requestEndpoint) => (location) => (field_name) => ({
             };
             const res = await requestEndpoint(params);
 
-            checkCommonErrorResponse(res);
-            expect(res.body.errors).toContainEqual({
-                "location": location,
-                "msg": ValidationReasons.BOOLEAN,
-                "param": field_name,
-                "value": params[field_name],
-            });
+            try {
+                checkCommonErrorResponse(res);
+                expect(res.body.errors).toContainEqual({
+                    "location": location,
+                    "msg": ValidationReasons.BOOLEAN,
+                    "param": field_name,
+                    "value": params[field_name],
+                });
+            } catch (e) {
+                throw new Error(`Failed mustBeBoolean test (${requestEndpoint}, ${location}, ${field_name})\n\n${e}`);
+            }
         });
     },
 
@@ -147,13 +179,17 @@ const ValidatorTester = (requestEndpoint) => (location) => (field_name) => ({
             };
             const res = await requestEndpoint(params);
 
-            checkCommonErrorResponse(res);
-            expect(res.body.errors).toContainEqual({
-                "location": location,
-                "msg": ValidationReasons.IN_ARRAY(array),
-                "param": field_name,
-                "value": params[field_name],
-            });
+            try {
+                checkCommonErrorResponse(res);
+                expect(res.body.errors).toContainEqual({
+                    "location": location,
+                    "msg": ValidationReasons.IN_ARRAY(array),
+                    "param": field_name,
+                    "value": params[field_name],
+                });
+            } catch (e) {
+                throw new Error(`Failed mustBeInArray test (${requestEndpoint}, ${location}, ${field_name})\n\n${e}`);
+            }
         });
     },
 
@@ -168,13 +204,17 @@ const ValidatorTester = (requestEndpoint) => (location) => (field_name) => ({
             };
             const res = await requestEndpoint(params);
 
-            checkCommonErrorResponse(res);
-            expect(res.body.errors).toContainEqual({
-                "location": location,
-                "msg": ValidationReasons.IN_ARRAY(array),
-                "param": field_name,
-                "value": params[field_name],
-            });
+            try {
+                checkCommonErrorResponse(res);
+                expect(res.body.errors).toContainEqual({
+                    "location": location,
+                    "msg": ValidationReasons.IN_ARRAY(array),
+                    "param": field_name,
+                    "value": params[field_name],
+                });
+            } catch (e) {
+                throw new Error(`Failed mustHaveValuesInRange test (${requestEndpoint}, ${location}, ${field_name})\n\n${e}`);
+            }
         });
     },
 
@@ -185,13 +225,17 @@ const ValidatorTester = (requestEndpoint) => (location) => (field_name) => ({
             };
             const res = await requestEndpoint(params);
 
-            checkCommonErrorResponse(res);
-            expect(res.body.errors).toContainEqual({
-                "location": location,
-                "msg": ValidationReasons.ARRAY_SIZE(arr_min, arr_max),
-                "param": field_name,
-                "value": params[field_name],
-            });
+            try {
+                checkCommonErrorResponse(res);
+                expect(res.body.errors).toContainEqual({
+                    "location": location,
+                    "msg": ValidationReasons.ARRAY_SIZE(arr_min, arr_max),
+                    "param": field_name,
+                    "value": params[field_name],
+                });
+            } catch (e) {
+                throw new Error(`Failed mustBeArrayBetween test (${requestEndpoint}, ${location}, ${field_name})\n\n${e}`);
+            }
         });
     },
 
@@ -203,13 +247,17 @@ const ValidatorTester = (requestEndpoint) => (location) => (field_name) => ({
 
             const res = await requestEndpoint(params);
 
-            checkCommonErrorResponse(res);
-            expect(res.body.errors).toContainEqual({
-                "location": location,
-                "msg": ValidationReasons.TOO_LONG(max_length),
-                "param": field_name,
-                "value": params[field_name],
-            });
+            try {
+                checkCommonErrorResponse(res);
+                expect(res.body.errors).toContainEqual({
+                    "location": location,
+                    "msg": ValidationReasons.TOO_LONG(max_length),
+                    "param": field_name,
+                    "value": params[field_name],
+                });
+            } catch (e) {
+                throw new Error(`Failed haxMaxLength test (${requestEndpoint}, ${location}, ${field_name})\n\n${e}`);
+            }
         });
     },
 
@@ -221,13 +269,17 @@ const ValidatorTester = (requestEndpoint) => (location) => (field_name) => ({
 
             const res = await requestEndpoint(params);
 
-            checkCommonErrorResponse(res);
-            expect(res.body.errors).toContainEqual({
-                "location": location,
-                "msg": ValidationReasons.TOO_SHORT(min_length),
-                "param": field_name,
-                "value": params[field_name],
-            });
+            try {
+                checkCommonErrorResponse(res);
+                expect(res.body.errors).toContainEqual({
+                    "location": location,
+                    "msg": ValidationReasons.TOO_SHORT(min_length),
+                    "param": field_name,
+                    "value": params[field_name],
+                });
+            } catch (e) {
+                throw new Error(`Failed hasMinLength test (${requestEndpoint}, ${location}, ${field_name})\n\n${e}`);
+            }
         });
     },
 
@@ -240,13 +292,17 @@ const ValidatorTester = (requestEndpoint) => (location) => (field_name) => ({
 
             const res = await requestEndpoint(params);
 
-            checkCommonErrorResponse(res);
-            expect(res.body.errors).toContainEqual({
-                "location": location,
-                "msg": ValidationReasons.EMAIL,
-                "param": field_name,
-                "value": params[field_name],
-            });
+            try {
+                checkCommonErrorResponse(res);
+                expect(res.body.errors).toContainEqual({
+                    "location": location,
+                    "msg": ValidationReasons.EMAIL,
+                    "param": field_name,
+                    "value": params[field_name],
+                });
+            } catch (e) {
+                throw new Error(`Failed mustBeEmail test (${requestEndpoint}, ${location}, ${field_name})\n\n${e}`);
+            }
         });
     },
 
@@ -258,13 +314,17 @@ const ValidatorTester = (requestEndpoint) => (location) => (field_name) => ({
 
             const res = await requestEndpoint(params);
 
-            checkCommonErrorResponse(res);
-            expect(res.body.errors).toContainEqual({
-                "location": location,
-                "msg": ValidationReasons.HAS_NUMBER,
-                "param": field_name,
-                "value": params[field_name],
-            });
+            try {
+                checkCommonErrorResponse(res);
+                expect(res.body.errors).toContainEqual({
+                    "location": location,
+                    "msg": ValidationReasons.HAS_NUMBER,
+                    "param": field_name,
+                    "value": params[field_name],
+                });
+            } catch (e) {
+                throw new Error(`Failed hasNumber test (${requestEndpoint}, ${location}, ${field_name})\n\n${e}`);
+            }
         });
     },
 });

--- a/test/utils/ValidatorTester.js
+++ b/test/utils/ValidatorTester.js
@@ -16,6 +16,23 @@ const checkCommonErrorResponse = (res) => {
 };
 
 /**
+ * Wraps the test in a try-catch to show additional context to the error message
+ * @param {*} context - the fields to show in the context message
+ * @param {*} test - the callback to execute (test)
+ */
+const executeValidatorTestWithContext = (context, test) => {
+    try {
+        test();
+    } catch (e) {
+        throw new Error(
+            `Failed isRequired test (${Object.entries(context)
+                .map(([k, v]) => `${k}: ${v}`)
+                .join(", ")
+            })\n\n${e}`);
+    }
+};
+
+/**
  * `requestEndpoint` is a method that receives params and calls the appropriate endpoint with the params if they exist/are appropriate.
  * Returns a promise (request() return value)
  *
@@ -28,17 +45,14 @@ const ValidatorTester = (requestEndpoint) => (location) => (field_name) => ({
             const params = {};
             const res = await requestEndpoint(params);
 
-            try {
+            executeValidatorTestWithContext({ requestEndpoint, location, field_name }, () => {
                 checkCommonErrorResponse(res);
-
                 expect(res.body.errors).toContainEqual({
                     "location": location,
                     "msg": ValidationReasons.REQUIRED,
                     "param": field_name,
                 });
-            } catch (e) {
-                throw new Error(`Failed isRequired test (${requestEndpoint}, ${location}, ${field_name})\n\n${e}`);
-            }
+            });
         });
     },
 
@@ -49,7 +63,7 @@ const ValidatorTester = (requestEndpoint) => (location) => (field_name) => ({
             };
             const res = await requestEndpoint(params);
 
-            try {
+            executeValidatorTestWithContext({ requestEndpoint, location, field_name }, () => {
                 checkCommonErrorResponse(res);
                 expect(res.body.errors).toContainEqual({
                     "location": location,
@@ -57,9 +71,7 @@ const ValidatorTester = (requestEndpoint) => (location) => (field_name) => ({
                     "param": field_name,
                     "value": params[field_name],
                 });
-            } catch (e) {
-                throw new Error(`Failed mustBeString test (${requestEndpoint}, ${location}, ${field_name})\n\n${e}`);
-            }
+            });
         });
     },
 
@@ -70,7 +82,7 @@ const ValidatorTester = (requestEndpoint) => (location) => (field_name) => ({
             };
             const res = await requestEndpoint(params);
 
-            try {
+            executeValidatorTestWithContext({ requestEndpoint, location, field_name }, () => {
                 checkCommonErrorResponse(res);
                 expect(res.body.errors).toContainEqual({
                     "location": location,
@@ -78,9 +90,7 @@ const ValidatorTester = (requestEndpoint) => (location) => (field_name) => ({
                     "param": field_name,
                     "value": params[field_name],
                 });
-            } catch (e) {
-                throw new Error(`Failed mustBeDate test (${requestEndpoint}, ${location}, ${field_name})\n\n${e}`);
-            }
+            });
         });
     },
 
@@ -91,8 +101,7 @@ const ValidatorTester = (requestEndpoint) => (location) => (field_name) => ({
             };
             const res = await requestEndpoint(params);
 
-            try {
-
+            executeValidatorTestWithContext({ requestEndpoint, location, field_name }, () => {
                 checkCommonErrorResponse(res);
                 expect(res.body.errors).toContainEqual({
                     "location": location,
@@ -100,9 +109,7 @@ const ValidatorTester = (requestEndpoint) => (location) => (field_name) => ({
                     "param": field_name,
                     "value": params[field_name],
                 });
-            } catch (e) {
-                throw new Error(`Failed mustBeFuture test (${requestEndpoint}, ${location}, ${field_name})\n\n${e}`);
-            }
+            });
         });
     },
 
@@ -115,8 +122,7 @@ const ValidatorTester = (requestEndpoint) => (location) => (field_name) => ({
 
             const res = await requestEndpoint(params);
 
-            try {
-
+            executeValidatorTestWithContext({ requestEndpoint, location, field_name }, () => {
                 checkCommonErrorResponse(res);
                 expect(res.body.errors).toContainEqual({
                     "location": location,
@@ -124,9 +130,7 @@ const ValidatorTester = (requestEndpoint) => (location) => (field_name) => ({
                     "param": field_name,
                     "value": params[field_name],
                 });
-            } catch (e) {
-                throw new Error(`Failed mustBeAfter test (${requestEndpoint}, ${location}, ${field_name})\n\n${e}`);
-            }
+            });
         });
     },
 
@@ -137,7 +141,7 @@ const ValidatorTester = (requestEndpoint) => (location) => (field_name) => ({
             };
             const res = await requestEndpoint(params);
 
-            try {
+            executeValidatorTestWithContext({ requestEndpoint, location, field_name }, () => {
                 checkCommonErrorResponse(res);
                 expect(res.body.errors).toContainEqual({
                     "location": location,
@@ -145,9 +149,7 @@ const ValidatorTester = (requestEndpoint) => (location) => (field_name) => ({
                     "param": field_name,
                     "value": params[field_name],
                 });
-            } catch (e) {
-                throw new Error(`Failed mustBeNumber test (${requestEndpoint}, ${location}, ${field_name})\n\n${e}`);
-            }
+            });
         });
     },
 
@@ -158,7 +160,7 @@ const ValidatorTester = (requestEndpoint) => (location) => (field_name) => ({
             };
             const res = await requestEndpoint(params);
 
-            try {
+            executeValidatorTestWithContext({ requestEndpoint, location, field_name }, () => {
                 checkCommonErrorResponse(res);
                 expect(res.body.errors).toContainEqual({
                     "location": location,
@@ -166,9 +168,7 @@ const ValidatorTester = (requestEndpoint) => (location) => (field_name) => ({
                     "param": field_name,
                     "value": params[field_name],
                 });
-            } catch (e) {
-                throw new Error(`Failed mustBeBoolean test (${requestEndpoint}, ${location}, ${field_name})\n\n${e}`);
-            }
+            });
         });
     },
 
@@ -179,7 +179,7 @@ const ValidatorTester = (requestEndpoint) => (location) => (field_name) => ({
             };
             const res = await requestEndpoint(params);
 
-            try {
+            executeValidatorTestWithContext({ requestEndpoint, location, field_name }, () => {
                 checkCommonErrorResponse(res);
                 expect(res.body.errors).toContainEqual({
                     "location": location,
@@ -187,9 +187,7 @@ const ValidatorTester = (requestEndpoint) => (location) => (field_name) => ({
                     "param": field_name,
                     "value": params[field_name],
                 });
-            } catch (e) {
-                throw new Error(`Failed mustBeInArray test (${requestEndpoint}, ${location}, ${field_name})\n\n${e}`);
-            }
+            });
         });
     },
 
@@ -204,7 +202,7 @@ const ValidatorTester = (requestEndpoint) => (location) => (field_name) => ({
             };
             const res = await requestEndpoint(params);
 
-            try {
+            executeValidatorTestWithContext({ requestEndpoint, location, field_name }, () => {
                 checkCommonErrorResponse(res);
                 expect(res.body.errors).toContainEqual({
                     "location": location,
@@ -212,9 +210,7 @@ const ValidatorTester = (requestEndpoint) => (location) => (field_name) => ({
                     "param": field_name,
                     "value": params[field_name],
                 });
-            } catch (e) {
-                throw new Error(`Failed mustHaveValuesInRange test (${requestEndpoint}, ${location}, ${field_name})\n\n${e}`);
-            }
+            });
         });
     },
 
@@ -225,7 +221,7 @@ const ValidatorTester = (requestEndpoint) => (location) => (field_name) => ({
             };
             const res = await requestEndpoint(params);
 
-            try {
+            executeValidatorTestWithContext({ requestEndpoint, location, field_name }, () => {
                 checkCommonErrorResponse(res);
                 expect(res.body.errors).toContainEqual({
                     "location": location,
@@ -233,9 +229,7 @@ const ValidatorTester = (requestEndpoint) => (location) => (field_name) => ({
                     "param": field_name,
                     "value": params[field_name],
                 });
-            } catch (e) {
-                throw new Error(`Failed mustBeArrayBetween test (${requestEndpoint}, ${location}, ${field_name})\n\n${e}`);
-            }
+            });
         });
     },
 
@@ -247,7 +241,7 @@ const ValidatorTester = (requestEndpoint) => (location) => (field_name) => ({
 
             const res = await requestEndpoint(params);
 
-            try {
+            executeValidatorTestWithContext({ requestEndpoint, location, field_name }, () => {
                 checkCommonErrorResponse(res);
                 expect(res.body.errors).toContainEqual({
                     "location": location,
@@ -255,9 +249,7 @@ const ValidatorTester = (requestEndpoint) => (location) => (field_name) => ({
                     "param": field_name,
                     "value": params[field_name],
                 });
-            } catch (e) {
-                throw new Error(`Failed haxMaxLength test (${requestEndpoint}, ${location}, ${field_name})\n\n${e}`);
-            }
+            });
         });
     },
 
@@ -269,7 +261,7 @@ const ValidatorTester = (requestEndpoint) => (location) => (field_name) => ({
 
             const res = await requestEndpoint(params);
 
-            try {
+            executeValidatorTestWithContext({ requestEndpoint, location, field_name }, () => {
                 checkCommonErrorResponse(res);
                 expect(res.body.errors).toContainEqual({
                     "location": location,
@@ -277,9 +269,7 @@ const ValidatorTester = (requestEndpoint) => (location) => (field_name) => ({
                     "param": field_name,
                     "value": params[field_name],
                 });
-            } catch (e) {
-                throw new Error(`Failed hasMinLength test (${requestEndpoint}, ${location}, ${field_name})\n\n${e}`);
-            }
+            });
         });
     },
 
@@ -292,7 +282,7 @@ const ValidatorTester = (requestEndpoint) => (location) => (field_name) => ({
 
             const res = await requestEndpoint(params);
 
-            try {
+            executeValidatorTestWithContext({ requestEndpoint, location, field_name }, () => {
                 checkCommonErrorResponse(res);
                 expect(res.body.errors).toContainEqual({
                     "location": location,
@@ -300,9 +290,7 @@ const ValidatorTester = (requestEndpoint) => (location) => (field_name) => ({
                     "param": field_name,
                     "value": params[field_name],
                 });
-            } catch (e) {
-                throw new Error(`Failed mustBeEmail test (${requestEndpoint}, ${location}, ${field_name})\n\n${e}`);
-            }
+            });
         });
     },
 
@@ -314,7 +302,7 @@ const ValidatorTester = (requestEndpoint) => (location) => (field_name) => ({
 
             const res = await requestEndpoint(params);
 
-            try {
+            executeValidatorTestWithContext({ requestEndpoint, location, field_name }, () => {
                 checkCommonErrorResponse(res);
                 expect(res.body.errors).toContainEqual({
                     "location": location,
@@ -322,9 +310,7 @@ const ValidatorTester = (requestEndpoint) => (location) => (field_name) => ({
                     "param": field_name,
                     "value": params[field_name],
                 });
-            } catch (e) {
-                throw new Error(`Failed hasNumber test (${requestEndpoint}, ${location}, ${field_name})\n\n${e}`);
-            }
+            });
         });
     },
 });


### PR DESCRIPTION
Closes #51 
Related to #43 
Closes #56 

If the logged-in user is a company, it uses that field as owner. Otherwise, it requires both god_token and owner fields to be authorized and to know which company to associate with the offer. Additionally, the owner is validated as an existing company id.