### PR TITLE
Enable proxy in express-session only in prod

### DIFF
--- a/src/loaders/express.js
+++ b/src/loaders/express.js
@@ -30,6 +30,11 @@ module.exports = (app) => {
         secret: config.session_secret,
         resave: true,
         saveUninitialized: true,
+
+        // Set to true only in prod. Necessary due to reverse proxy setup
+        // Check https://github.com/expressjs/session/issues/281 for more details
+        proxy: process.env.NODE_ENV === "production",
+
         cookie: {
             secure: process.env.NODE_ENV === "production",
         },


### PR DESCRIPTION
Closes #104 

The issue says pretty much everything, this ensures that secure cookies work and fixes the auth problem in prod.