### PR TITLE
Fix error type when rejecting/accepting applications

### DIFF
--- a/src/services/application.js
+++ b/src/services/application.js
@@ -169,11 +169,9 @@ class CompanyApplicationService {
 
     async approve(id, options) {
 
-        let application;
-
+        const application = await CompanyApplication.findById(id, {}, options);
+        if (!application) throw new CompanyApplicationNotFound(CompanyApplicationRules.MUST_EXIST_TO_APPROVE.msg);
         try {
-            application = await CompanyApplication.findById(id, {}, options);
-            if (!application) throw new CompanyApplicationNotFound(CompanyApplicationRules.MUST_EXIST_TO_APPROVE.msg);
             application.approve();
         } catch (e) {
             throw new CompanyApplicationAlreadyReiewed(CompanyApplicationRules.CANNOT_REVIEW_TWICE.msg);
@@ -201,10 +199,9 @@ class CompanyApplicationService {
     }
 
     async reject(id, reason, options) {
+        const application = (await CompanyApplication.findById(id, {}, options));
+        if (!application) throw new CompanyApplicationNotFound(CompanyApplicationRules.MUST_EXIST_TO_REJECT.msg);
         try {
-            const application = (await CompanyApplication.findById(id, {}, options));
-            if (!application) throw new CompanyApplicationNotFound(CompanyApplicationRules.MUST_EXIST_TO_REJECT.msg);
-
             application.reject(reason);
 
             await EmailService.sendMail({

--- a/test/end-to-end/review.js
+++ b/test/end-to-end/review.js
@@ -328,7 +328,7 @@ describe("Company application review endpoint test", () => {
                         const res = await test_agent
                             .post(`/applications/company/${new ObjectId()}/approve`);
 
-                        expect(res.status).toBe(HTTPStatus.CONFLICT);
+                        expect(res.status).toBe(HTTPStatus.NOT_FOUND);
                     });
 
                     test("Should fail if trying to approve already approved application", async () => {
@@ -422,7 +422,7 @@ describe("Company application review endpoint test", () => {
                             .post(`/applications/company/${new ObjectId()}/reject`)
                             .send({ rejectReason: "Some reason which is valid" });
 
-                        expect(res.status).toBe(HTTPStatus.CONFLICT);
+                        expect(res.status).toBe(HTTPStatus.NOT_FOUND);
                     });
 
                     test("Should fail if trying to reject already approved application", async () => {


### PR DESCRIPTION
The error sent when the application does not exist was corrected from "already reviewed" to "does not exist".