### PR TITLE
Fix/publish time limit

### DIFF
--- a/src/api/middleware/validators/offer.js
+++ b/src/api/middleware/validators/offer.js
@@ -11,11 +11,14 @@ const OfferConstants = require("../../../models/constants/Offer");
 const Company = require("../../../models/Company");
 const { isObjectId } = require("../validators/validatorUtils");
 const Offer = require("../../../models/Offer");
+const { validatePublishEndDateLimit } = require("../../../models/Offer");
 const { ErrorTypes } = require("../errorHandler");
 const HTTPStatus = require("http-status-codes");
 const {
     HOUR_IN_MS,
     OFFER_EDIT_GRACE_PERIOD_HOURS,
+    MONTH_IN_MS,
+    OFFER_MAX_LIFETIME_MONTHS
 } = require("../../../models/constants/TimeConstants");
 
 const mustSpecifyJobMinDurationIfJobMaxDurationSpecified = (jobMaxDuration, { req }) => {
@@ -38,6 +41,33 @@ const jobMaxDurationGreaterOrEqualThanJobMinDuration = (jobMaxDuration, { req })
     return true;
 };
 
+const publishEndDateAfterPublishDate = (publishEndDateCandidate, { req }) => {
+    const { publishDate: publishDateCandidate } = req.body;
+    // Default values and also handling if it is string or date object
+    const publishDate = publishDateCandidate || (new Date(Date.now())).toISOString();
+
+    if (publishEndDateCandidate <= publishDate) {
+        // end date is earlier than publish date, error!
+        throw new Error(ValidationReasons.MUST_BE_AFTER("publishDate"));
+    }
+
+    // Returning truthy value to indicate no error ocurred
+    return true;
+};
+
+const publishEndDateLimit = (publishEndDateCandidate, { req }) => {
+    const { publishDate: publishDateCandidate } = req.body;
+    // Default values and also handling if it is string or date object
+    const publishDate = publishDateCandidate || (new Date(Date.now()));
+    if (!validatePublishEndDateLimit(new Date(Date.parse(publishDate)), new Date(Date.parse(publishEndDateCandidate)))) {
+        const maxPublishEndDate = new Date(Date.parse(publishDate) + (MONTH_IN_MS * OFFER_MAX_LIFETIME_MONTHS)).toISOString();
+        throw new Error(ValidationReasons.MUST_BE_BEFORE(maxPublishEndDate));
+    }
+
+    // Returning truthy value to indicate no error ocurred
+    return true;
+};
+
 const create = useExpressValidators([
     body("title", ValidationReasons.DEFAULT)
         .exists().withMessage(ValidationReasons.REQUIRED).bail()
@@ -53,19 +83,8 @@ const create = useExpressValidators([
         .exists().withMessage(ValidationReasons.REQUIRED).bail()
         .isISO8601({ strict: true }).withMessage(ValidationReasons.DATE).bail()
         .isAfter().withMessage(ValidationReasons.DATE_EXPIRED).bail()
-        .custom((publishEndDateCandidate, { req }) => {
-            const { publishDate: publishDateCandidate } = req.body;
-            // Default values and also handling if it is string or date object
-            const publishDate = publishDateCandidate || (new Date(Date.now())).toISOString();
-
-            if (publishEndDateCandidate <= publishDate) {
-                // end date is earlier than publish date, error!
-                throw new Error(ValidationReasons.MUST_BE_AFTER("publishDate"));
-            }
-
-            // Returning truthy value to indicate no error ocurred
-            return true;
-        }),
+        .custom(publishEndDateAfterPublishDate)
+        .custom(publishEndDateLimit),
 
     body("jobMinDuration", ValidationReasons.DEFAULT)
         .optional()
@@ -211,7 +230,7 @@ const publishDateEditable = async (publishDateCandidate, { req }) => {
 
         // If the new publishEndDate is after the new publishDate, the verification will be done in publishEndDate
         if (publishDateCandidate >= offer.publishEndDate.toISOString() &&
-                !publishEndDateCandidate) {
+            !publishEndDateCandidate) {
 
             // end date is earlier than publish date, error!
             throw new Error(ValidationReasons.MUST_BE_BEFORE("publishEndDate"));
@@ -289,7 +308,8 @@ const edit = useExpressValidators([
         .optional()
         .isISO8601({ strict: true }).withMessage(ValidationReasons.DATE).bail()
         .isAfter().withMessage(ValidationReasons.DATE_EXPIRED).bail()
-        .custom(publishEndDateEditable),
+        .custom(publishEndDateEditable)
+        .custom(publishEndDateLimit),
 
     body("jobMinDuration", ValidationReasons.DEFAULT)
         .optional()

--- a/src/api/middleware/validators/offer.js
+++ b/src/api/middleware/validators/offer.js
@@ -86,6 +86,7 @@ const create = useExpressValidators([
         .custom(publishEndDateAfterPublishDate)
         .custom(publishEndDateLimit),
 
+
     body("jobMinDuration", ValidationReasons.DEFAULT)
         .optional()
         .isInt().withMessage(ValidationReasons.INT),

--- a/src/models/Offer.js
+++ b/src/models/Offer.js
@@ -107,8 +107,13 @@ function validatePublishDate(value) {
 }
 
 function validateEndDate(value) {
+    return validatePublishEndDateLimit(this.publishDate, value);
+}
+
+function validatePublishEndDateLimit(publishDate, publishEndDate) {
+
     // Milisseconds from publish date to end date (Offer is no longer valid)
-    const timeDiff = value.getTime() - this.publishDate.getTime();
+    const timeDiff = publishEndDate.getTime() - publishDate.getTime();
     const diffInMonths = timeDiff / MONTH_IN_MS;
 
     return diffInMonths <= OFFER_MAX_LIFETIME_MONTHS;
@@ -150,3 +155,4 @@ const Offer = mongoose.model("Offer", OfferSchema);
 // console.log("DBG: ", OfferSchema.path("location"));
 
 module.exports = Offer;
+module.exports.validatePublishEndDateLimit = validatePublishEndDateLimit;

--- a/test/end-to-end/offer.js
+++ b/test/end-to-end/offer.js
@@ -15,7 +15,13 @@ const hash = require("../../src/lib/passwordHashing");
 const ValidationReasons = require("../../src/api/middleware/validators/validationReasons");
 const { Types } = require("mongoose");
 const CompanyConstants = require("../../src/models/constants/Company");
-const { OFFER_EDIT_GRACE_PERIOD_HOURS, HOUR_IN_MS  } = require("../../src/models/constants/TimeConstants");
+const {
+    OFFER_EDIT_GRACE_PERIOD_HOURS,
+    HOUR_IN_MS,
+    MONTH_IN_MS,
+    OFFER_MAX_LIFETIME_MONTHS
+} = require("../../src/models/constants/TimeConstants");
+const { ensureArray } = require("../../src/api/middleware/validators/validatorUtils");
 
 //----------------------------------------------------------------
 describe("Offer endpoint tests", () => {
@@ -283,6 +289,35 @@ describe("Offer endpoint tests", () => {
         describe("Without pre-existing offers", () => {
             beforeAll(async () => {
                 await Offer.deleteMany({});
+            });
+
+            beforeEach(async () => {
+                await Offer.deleteMany({});
+            });
+
+            test("Should fail to create an offer due to publish end date being aftr publish date more than the limit", async () => {
+                const offer = generateTestOffer();
+                const publishDate = new Date(Date.now() - (DAY_TO_MS));
+                const offer_params = {
+                    ...offer,
+                    owner: test_company._id,
+                    ownerName: test_company.name,
+                    publishDate: publishDate.toISOString(),
+                    publishEndDate: (new Date(publishDate.getTime() + (MONTH_IN_MS * OFFER_MAX_LIFETIME_MONTHS) + DAY_TO_MS)).toISOString(),
+                };
+
+                const res = await request()
+                    .post("/offers/new")
+                    .send(withGodToken(offer_params));
+
+                expect(res.body).toHaveProperty("error_code", ErrorTypes.VALIDATION_ERROR);
+                expect(res.body.errors).toHaveLength(1);
+                expect(res.body.errors[0]).toHaveProperty("param", "publishEndDate");
+                expect(res.body.errors[0]).toHaveProperty("location", "body");
+                expect(res.body.errors[0].msg).toEqual(
+                    ValidationReasons.MUST_BE_BEFORE(
+                        new Date(publishDate.getTime() + (MONTH_IN_MS * OFFER_MAX_LIFETIME_MONTHS)).toISOString()
+                    ));
             });
 
             // TODO: This test should be 'with minimum requirements'
@@ -1394,8 +1429,8 @@ describe("Offer endpoint tests", () => {
                         .post(`/offers/edit/${future_test_offer._id.toString()}`)
                         .send(withGodToken({
                             "publishDate":
-                            (new Date(new Date(future_test_offer.publishEndDate).getTime() + DAY_TO_MS))
-                                .toISOString()
+                                (new Date(new Date(future_test_offer.publishEndDate).getTime() + DAY_TO_MS))
+                                    .toISOString()
                         }))
                         .expect(HTTPStatus.UNPROCESSABLE_ENTITY);
                     expect(res.body.errors[0]).toHaveProperty("param", "publishDate");
@@ -1407,8 +1442,8 @@ describe("Offer endpoint tests", () => {
                         .post(`/offers/edit/${future_test_offer._id.toString()}`)
                         .send(withGodToken({
                             "publishEndDate":
-                            (new Date(new Date(future_test_offer.publishDate).getTime() - DAY_TO_MS))
-                                .toISOString()
+                                (new Date(new Date(future_test_offer.publishDate).getTime() - DAY_TO_MS))
+                                    .toISOString()
                         }))
                         .expect(HTTPStatus.UNPROCESSABLE_ENTITY);
                     expect(res.body.errors[0]).toHaveProperty("param", "publishEndDate");


### PR DESCRIPTION
Closes #98 

Added validators to the publishEndDate of a offer to both the create and edit operations. The publishEndDate must not exceeda time limit that is defined in the TimeConstants