### PR TITLE
Add verification for jobMaxDuration greater than jobMinDuration on requests level

### DIFF
--- a/src/api/middleware/validators/offer.js
+++ b/src/api/middleware/validators/offer.js
@@ -53,7 +53,20 @@ const create = useExpressValidators([
 
     body("jobMaxDuration", ValidationReasons.DEFAULT)
         .optional()
-        .isInt().withMessage(ValidationReasons.INT),
+        .isInt().withMessage(ValidationReasons.INT)
+        .custom((jobMaxDuration, { req }) => {
+            try {
+                const { jobMinDuration } = req.body;
+
+                if (jobMinDuration >= jobMaxDuration) {
+                    throw new Error(ValidationReasons.MUST_BE_AFTER("jobMinDuration"));
+                }
+            } catch (err) {
+                console.error(err);
+                throw err;
+            }
+            return true;
+        }),
 
     body("jobStartDate", ValidationReasons.DEFAULT)
         .optional()

--- a/src/api/middleware/validators/validationReasons.js
+++ b/src/api/middleware/validators/validationReasons.js
@@ -29,6 +29,7 @@ const ValidationReasons = Object.freeze({
     OFFER_EXPIRED: (id) => `offer-expired:${id}`,
     NOT_OFFER_OWNER: (id) => `not-offer-owner:${id}`,
     OFFER_EDIT_PERIOD_OVER: (value) => `offer-edit-period-over:${value}-hours`,
+    JOB_MIN_DURATION_NOT_SPECIFIED: "job-max-duration-requires-job-min-duration",
 });
 
 module.exports = ValidationReasons;

--- a/src/models/Offer.js
+++ b/src/models/Offer.js
@@ -116,7 +116,7 @@ function validateEndDate(value) {
 
 // jobMaxDuration must be larger than jobMinDuration
 function validateJobMaxDuration(value) {
-    return value > this.jobMinDuration;
+    return value >= this.jobMinDuration;
 }
 
 function validateOwnerConcurrentOffers(value) {

--- a/src/models/Offer.js
+++ b/src/models/Offer.js
@@ -116,7 +116,7 @@ function validateEndDate(value) {
 
 // jobMaxDuration must be larger than jobMinDuration
 function validateJobMaxDuration(value) {
-    return value >= this.jobMinDuration;
+    return value > this.jobMinDuration;
 }
 
 function validateOwnerConcurrentOffers(value) {

--- a/test/end-to-end/offer.js
+++ b/test/end-to-end/offer.js
@@ -479,6 +479,42 @@ describe("Offer endpoint tests", () => {
                 expect(created_offer).toHaveProperty("publishDate");
             });
         });
+
+        describe("Job Duration", () => {
+            test("should fail if jobMinDuration is greater than jobMaxDuration", async () => {
+                const offer_params = generateTestOffer({
+                    jobMinDuration: 10,
+                    jobMaxDuration: 8,
+                    owner: test_company._id,
+                    ownerName: test_company.name,
+                });
+
+                const res = await request()
+                    .post("/offers/new")
+                    .send(withGodToken(offer_params));
+
+                expect(res.status).toBe(HTTPStatus.UNPROCESSABLE_ENTITY);
+                expect(res.body).toHaveProperty("error_code", ErrorTypes.VALIDATION_ERROR);
+                expect(res.body).toHaveProperty("errors");
+                expect(res.body.errors[0]).toHaveProperty("param", "jobMaxDuration");
+                expect(res.body.errors[0]).toHaveProperty("msg", ValidationReasons.MUST_BE_AFTER("jobMinDuration"));
+            });
+
+            test("should succeed if jobMaxDuration is greater than jobMinDuration", async () => {
+                const offer_params = generateTestOffer({
+                    jobMinDuration: 8,
+                    jobMaxDuration: 10,
+                    owner: test_company._id,
+                    ownerName: test_company.name,
+                });
+
+                const res = await request()
+                    .post("/offers/new")
+                    .send(withGodToken(offer_params));
+
+                expect(res.status).toBe(HTTPStatus.OK);
+            });
+        });
     });
 
     describe("GET /offers", () => {

--- a/test/end-to-end/offer.js
+++ b/test/end-to-end/offer.js
@@ -514,6 +514,38 @@ describe("Offer endpoint tests", () => {
 
                 expect(res.status).toBe(HTTPStatus.OK);
             });
+
+            test("should fail if jobMaxDuration is specified and jobMinDuration isn't", async () => {
+                const offer_params = generateTestOffer({
+                    jobMaxDuration: 8,
+                    owner: test_company._id,
+                    ownerName: test_company.name,
+                });
+
+                const res = await request()
+                    .post("/offers/new")
+                    .send(withGodToken(offer_params));
+
+                expect(res.status).toBe(HTTPStatus.UNPROCESSABLE_ENTITY);
+                expect(res.body).toHaveProperty("error_code", ErrorTypes.VALIDATION_ERROR);
+                expect(res.body).toHaveProperty("errors");
+                expect(res.body.errors[0]).toHaveProperty("param", "jobMaxDuration");
+                expect(res.body.errors[0]).toHaveProperty("msg", ValidationReasons.JOB_MIN_DURATION_NOT_SPECIFIED);
+            });
+
+            test("should succeed if jobMinDuration is specified and jobMaxDuration isn't", async () => {
+                const offer_params = generateTestOffer({
+                    jobMinDuration: 8,
+                    owner: test_company._id,
+                    ownerName: test_company.name,
+                });
+
+                const res = await request()
+                    .post("/offers/new")
+                    .send(withGodToken(offer_params));
+
+                expect(res.status).toBe(HTTPStatus.OK);
+            });
         });
     });
 


### PR DESCRIPTION
Added a new custom validator to the offers creation endpoint that verifies that jobMaxDuration > jobMinDuration, if they are present