### PR TITLE
Hotfix for concurrent offers validator when nonoverlapping offers exist in the time period

### DIFF
--- a/src/api/middleware/validators/validatorUtils.js
+++ b/src/api/middleware/validators/validatorUtils.js
@@ -73,18 +73,16 @@ const concurrentOffersNotExceeded = (OfferModel) => async (owner, publishDate, p
     startDates.sort();
     endDates.sort();
 
+    /**
+     * This algorithm is explained in https://github.com/NIAEFEUP/nijobs-be/issues/123#issuecomment-782272539
+     */
     let counter = 0, maxConcurrent = 0;
     let startIndex = 0, endIndex = 0;
     while (startIndex < offerNumber || endIndex < offerNumber) {
-        if (startIndex < offerNumber) {
-            if (endIndex >= offerNumber || startDates[startIndex] <= endDates[endIndex]) {
-                counter++;
-                startIndex++;
-                if (counter > maxConcurrent) maxConcurrent = counter;
-            } else {
-                counter--;
-                endIndex++;
-            }
+        if (startIndex < offerNumber && (endIndex >= offerNumber || startDates[startIndex] <= endDates[endIndex])) {
+            counter++;
+            startIndex++;
+            if (counter > maxConcurrent) maxConcurrent = counter;
         } else {
             counter--;
             endIndex++;

--- a/src/api/middleware/validators/validatorUtils.js
+++ b/src/api/middleware/validators/validatorUtils.js
@@ -53,7 +53,8 @@ const isObjectId = (id) => {
 };
 
 /**
- * Checks if the concurrent offers of a given owner have not exceeded the defined limit
+ * Checks if the concurrent offers of a given owner have not exceeded the defined limit.
+ * If the offers in the timed period exceed the limit, checks how many are concurrent.
  * @param {*} OfferModel Either the default Offer model or an instance's constructor
  * @param {*} owner Owner of the offer
  * @param {*} publishDate Publish date of the
@@ -66,20 +67,19 @@ const concurrentOffersNotExceeded = (OfferModel) => async (owner, publishDate, p
 
     const offerNumber = offersInTimePeriod.length;
     if (offerNumber < CompanyConstants.offers.max_concurrent) return true;
-    // otherwise, let's check how many are concurrent
 
     // This algorithm is explained in https://github.com/NIAEFEUP/nijobs-be/issues/123#issuecomment-782272539
 
-    const offersByStart = offersInTimePeriod; // we won't need this array unmodified
-    const offersByEnd = [...offersInTimePeriod];
-    offersByStart.sort((offer1, offer2) => Date.parse(offer1.publishDate) - Date.parse(offer2.publishDate));
-    offersByEnd.sort((offer1, offer2) => Date.parse(offer1.publishEndDate) - Date.parse(offer2.publishEndDate));
+    const offersSortedByStart = offersInTimePeriod; // we won't need this array unmodified
+    const offersSortedByEnd = [...offersInTimePeriod];
+    offersSortedByStart.sort((offer1, offer2) => Date.parse(offer1.publishDate) - Date.parse(offer2.publishDate));
+    offersSortedByEnd.sort((offer1, offer2) => Date.parse(offer1.publishEndDate) - Date.parse(offer2.publishEndDate));
 
     let counter = 0, maxConcurrent = 0;
     let startIndex = 0, endIndex = 0;
     while (startIndex < offerNumber || endIndex < offerNumber) {
         if (startIndex < offerNumber &&
-            (endIndex >= offerNumber || offersByStart[startIndex].publishDate <= offersByEnd[endIndex].publishEndDate)) {
+            (endIndex >= offerNumber || offersSortedByStart[startIndex].publishDate <= offersSortedByEnd[endIndex].publishEndDate)) {
 
             counter++;
             startIndex++;

--- a/src/api/middleware/validators/validatorUtils.js
+++ b/src/api/middleware/validators/validatorUtils.js
@@ -52,6 +52,8 @@ const isObjectId = (id) => {
     return true;
 };
 
+const sortOffersByFieldAscending = (field) => (offer1, offer2) => Date.parse(offer1[field]) - Date.parse(offer2[field]);
+
 /**
  * Checks if the concurrent offers of a given owner have not exceeded the defined limit.
  * If the offers in the timed period exceed the limit, checks how many are concurrent.
@@ -72,8 +74,8 @@ const concurrentOffersNotExceeded = (OfferModel) => async (owner, publishDate, p
 
     const offersSortedByStart = offersInTimePeriod; // we won't need this array unmodified
     const offersSortedByEnd = [...offersInTimePeriod];
-    offersSortedByStart.sort((offer1, offer2) => Date.parse(offer1.publishDate) - Date.parse(offer2.publishDate));
-    offersSortedByEnd.sort((offer1, offer2) => Date.parse(offer1.publishEndDate) - Date.parse(offer2.publishEndDate));
+    offersSortedByStart.sort(sortOffersByFieldAscending("publishDate"));
+    offersSortedByEnd.sort(sortOffersByFieldAscending("publishEndDate"));
 
     let counter = 0, maxConcurrent = 0;
     let startIndex = 0, endIndex = 0;

--- a/test/end-to-end/offer.js
+++ b/test/end-to-end/offer.js
@@ -480,7 +480,8 @@ describe("Offer endpoint tests", () => {
             });
         });
 
-        describe("Creating an offer in a time period with nonoverlapping offers", () => {
+        describe("Creating an offer in a time period with more than `max_concurrent` overlapping offers, \
+                    without exceeding the limit at any point", () => {
             const testOffers = Array(CompanyConstants.offers.max_concurrent - 2)
                 .fill(generateTestOffer({
                     "publishDate": (new Date(Date.now() + (2 * DAY_TO_MS))).toISOString(),
@@ -506,10 +507,6 @@ describe("Offer endpoint tests", () => {
                 });
 
                 await Offer.create(testOffers);
-            });
-
-            afterAll(async () => {
-                await Offer.deleteMany({});
             });
 
             test("should succeed to create an offer (the offers limit is never reached at any moment)", async () => {

--- a/test/end-to-end/offer.js
+++ b/test/end-to-end/offer.js
@@ -480,6 +480,56 @@ describe("Offer endpoint tests", () => {
             });
         });
 
+        describe("Creating an offer in a time period with nonoverlapping offers", () => {
+            const testOffers = Array(CompanyConstants.offers.max_concurrent - 2)
+                .fill(generateTestOffer({
+                    "publishDate": (new Date(Date.now() + (2 * DAY_TO_MS))).toISOString(),
+                    "publishEndDate": (new Date(Date.now() + (10 * DAY_TO_MS))).toISOString()
+                }));
+
+            testOffers.push(generateTestOffer({
+                "publishDate": (new Date(Date.now())).toISOString(),
+                "publishEndDate": (new Date(Date.now() + (5 * DAY_TO_MS))).toISOString()
+            }));
+
+            testOffers.push(generateTestOffer({
+                "publishDate": (new Date(Date.now() + (8 * DAY_TO_MS))).toISOString(),
+                "publishEndDate": (new Date(Date.now() + (12 * DAY_TO_MS))).toISOString()
+            }));
+
+            beforeAll(async () => {
+                await Offer.deleteMany({});
+
+                testOffers.forEach((offer) => {
+                    offer.owner = test_company._id;
+                    offer.ownerName = test_company.name;
+                });
+
+                await Offer.create(testOffers);
+            });
+
+            afterAll(async () => {
+                await Offer.deleteMany({});
+            });
+
+            test("should succeed to create an offer (the offers limit is never reached at any moment)", async () => {
+                const offer_params = generateTestOffer({
+                    "publishDate": (new Date(Date.now() + (4 * DAY_TO_MS))).toISOString(),
+                    "publishEndDate": (new Date(Date.now() + (9 * DAY_TO_MS))).toISOString(),
+                    owner: test_company._id,
+                    ownerName: test_company.name
+                });
+
+                const res = await request()
+                    .post("/offers/new")
+                    .send(withGodToken(offer_params));
+
+                expect(res.status).toBe(HTTPStatus.OK);
+                expect(res.body.publishDate).toBe(offer_params.publishDate);
+                expect(res.body.publishEndDate).toBe(offer_params.publishEndDate);
+            });
+        });
+
         describe("Default values", () => {
             test("publishDate defaults to the current time if not provided", async () => {
                 const offer = {


### PR DESCRIPTION
Right now, the concurrentOffersNotExceeded function, which is used to validate offers in the route and model levels, only counts all offers in a time period for a specific owner. This PR tries to fix this