### PR TITLE
Apply the .current query to both text search and non-text search

### DIFF
--- a/src/services/offer.js
+++ b/src/services/offer.js
@@ -122,9 +122,9 @@ class OfferService {
      */
     get({ value = "", offset = 0, limit = OfferService.MAX_OFFERS_PER_QUERY, showHidden = false, ...filters }) {
 
-        const offers = value ? Offer.find(
+        const offers = (value ? Offer.find(
             { "$and": [this._buildFilterQuery(filters), { "$text": { "$search": value } }] }, { score: { "$meta": "textScore" } }
-        ) : Offer.find(this._buildFilterQuery(filters)).current();
+        ) : Offer.find(this._buildFilterQuery(filters))).current();
 
         if (!showHidden) offers.withoutHidden();
 

--- a/test/end-to-end/offer.js
+++ b/test/end-to-end/offer.js
@@ -645,9 +645,36 @@ describe("Offer endpoint tests", () => {
                 });
 
 
-                test("should provide only current offer info (no expired or future offers)", async () => {
+                test("should provide only current offer info (no expired or future offers with no value query)", async () => {
                     const res = await request()
                         .get("/offers");
+
+                    expect(res.status).toBe(HTTPStatus.OK);
+                    expect(res.body).toHaveLength(1);
+                    // Necessary because jest matchers appear to not be working (expect.any(Number), expect.anthing(), etc)
+                    const extracted_data = res.body.map((elem) => {
+                        delete elem["_id"];
+                        delete elem["__v"];
+                        delete elem["createdAt"];
+                        delete elem["updatedAt"];
+                        delete elem["score"];
+                        return elem;
+                    });
+                    const prepared_test_offer = {
+                        ...test_offer,
+                        isHidden: false,
+                        owner: test_offer.owner.toString()
+                    };
+
+                    expect(extracted_data).toContainEqual(prepared_test_offer);
+                });
+
+                test("should provide only current offer info (no expired or future offers with some value query)", async () => {
+                    const res = await request()
+                        .get("/offers")
+                        .query({
+                            value: "test",
+                        });
 
                     expect(res.status).toBe(HTTPStatus.OK);
                     expect(res.body).toHaveLength(1);


### PR DESCRIPTION
Currently, if a text query was supplied to offer search, it would not filter by `current` only, as it did when no text query was provided. This PR fixes that.