### PR TITLE
Changed queries for job duration filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # niJobs - BackEnd
 
-[![Build Status](https://img.shields.io/travis/NIAEFEUP/nijobs-be/develop.svg?style=for-the-badge)](https://travis-ci.org/NIAEFEUP/nijobs-be)
+![GitHub Workflow Status (branch)](https://img.shields.io/github/workflow/status/NIAEFEUP/nijobs-be/CI/master?label=BUILD%20-%20Master&style=for-the-badge)
+![GitHub Workflow Status (branch)](https://img.shields.io/github/workflow/status/NIAEFEUP/nijobs-be/CI/develop?label=BUILD%20-%20Develop&style=for-the-badge)
+
+
 [![GitHub issues](https://img.shields.io/github/issues/NIAEFEUP/nijobs-be.svg?style=for-the-badge)](https://github.com/NIAEFEUP/nijobs-be/issues)
 [![GitHub license](https://img.shields.io/github/license/NIAEFEUP/nijobs-be.svg?style=for-the-badge)](https://github.com/NIAEFEUP/nijobs-be/blob/master/LICENSE)
 

--- a/src/services/offer.js
+++ b/src/services/offer.js
@@ -142,8 +142,40 @@ class OfferService {
         const constraints = [];
 
         if (jobType) constraints.push({ jobType: { "$in": jobType } });
-        if (jobMinDuration) constraints.push({ jobMinDuration: { "$gte": jobMinDuration } });
-        if (jobMaxDuration) constraints.push({ jobMaxDuration: { "$lte": jobMaxDuration } });
+        if (jobMinDuration) {
+            constraints.push({
+                "$or": [
+                    { jobMinDuration: { "$exists": false } },
+                    { jobMinDuration: { "$gte": jobMinDuration } },
+                    {
+                        "$and": [
+                            { jobMinDuration: { "$lt": jobMinDuration } },
+                            { "$or": [
+                                { jobMaxDuration: { "$exists": false } },
+                                { jobMaxDuration: { "$gte": jobMinDuration } },
+                            ] }
+                        ]
+                    },
+                ]
+            });
+        }
+        if (jobMaxDuration) {
+            constraints.push({
+                "$or": [
+                    { jobMaxDuration: { "$exists": false } },
+                    { jobMaxDuration: { "$lte": jobMaxDuration } },
+                    {
+                        "$and": [
+                            { jobMaxDuration: { "$gt": jobMaxDuration } },
+                            { "$or": [
+                                { jobMinDuration: { "$exists": false } },
+                                { jobMinDuration: { "$lte": jobMaxDuration } },
+                            ] }
+                        ]
+                    },
+                ]
+            });
+        }
         if (fields?.length) constraints.push({ fields: {  "$elemMatch": { "$in": fields } } });
         if (technologies?.length) constraints.push({ technologies: {  "$elemMatch": { "$in": technologies } } });
 

--- a/test/end-to-end/offer.js
+++ b/test/end-to-end/offer.js
@@ -1153,6 +1153,8 @@ describe("Offer endpoint tests", () => {
 
                 test("should return porto offers with min duration of 2 and max duration of 4", async () => {
 
+                    // This test should include the 3-6 offer as well, since [3,6] intersects [2,4]
+
                     const res = await request()
                         .get("/offers")
                         .query({
@@ -1161,7 +1163,7 @@ describe("Offer endpoint tests", () => {
                             jobMaxDuration: 4
                         });
                     expect(res.status).toBe(HTTPStatus.OK);
-                    expect(res.body).toHaveLength(1);
+                    expect(res.body).toHaveLength(2);
 
                     // Necessary because jest matchers appear to not be working (expect.any(Number), expect.anthing(), etc)
                     const extracted_data = res.body.map((elem) => {
@@ -1169,13 +1171,16 @@ describe("Offer endpoint tests", () => {
                         return elem;
                     });
 
-                    const prepared_test_offer = {
-                        ...portoBackend,
+                    // eslint-disable-next-line no-unused-vars
+                    const expected_offers = [portoBackend, portoFrontend].map(({ owner, ...offer }) => ({
+                        ...offer,
                         isHidden: false,
-                        owner: portoBackend.owner.toString()
-                    };
+                        owner: owner.toString()
+                    }));
 
-                    expect(extracted_data).toContainEqual(prepared_test_offer);
+                    expected_offers.forEach((expected) => {
+                        expect(extracted_data).toContainEqual(expected);
+                    });
                 });
             });
 


### PR DESCRIPTION
Fixes the advanced search related to job duration in offers.

Now it takes into account undefined/null values and it's also possible to get offers that intersect the limit, as long as they are valid on the correct "side" (e.g. an offer with job duration 3-6 months should appear if the max duration filter is set to 5, since it can (in theory) last for 3, 4 or 5 months as well.