### PR TITLE
Set default value for publishDate

### DIFF
--- a/src/api/middleware/validators/offer.js
+++ b/src/api/middleware/validators/offer.js
@@ -447,6 +447,11 @@ const offersDateSanitizers = useExpressValidators([
         .toDate(),
 ]);
 
+const setDefaultValuesCreate = (req, res, next) => {
+    if (!req.body?.publishDate) req.body.publishDate = new Date(Date.now()).toISOString();
+    return next();
+};
+
 const get = useExpressValidators([
     query("offset", ValidationReasons.DEFAULT)
         .optional()
@@ -552,6 +557,7 @@ module.exports = {
     isExistingOffer,
     edit,
     offersDateSanitizers,
+    setDefaultValuesCreate,
     isEditable,
     canBeManaged,
     canBeEnabled,

--- a/src/api/routes/offer.js
+++ b/src/api/routes/offer.js
@@ -60,6 +60,7 @@ module.exports = (app) => {
      * Creates a new Offer
      */
     router.post("/new",
+        validators.setDefaultValuesCreate,
         or([
             authMiddleware.isCompany,
             authMiddleware.isAdmin,

--- a/test/end-to-end/offer.js
+++ b/test/end-to-end/offer.js
@@ -438,6 +438,25 @@ describe("Offer endpoint tests", () => {
                 expect(res.body.errors).toContainEqual(
                     ValidationReasons.MAX_CONCURRENT_OFFERS_EXCEEDED(CompanyConstants.offers.max_concurrent));
             });
+
+            test("should fail to create a new offer (with default publishDate)", async () => {
+                const offer_params = {
+                    ...generateTestOffer(),
+                    owner: test_company._id,
+                    ownerName: test_company.name,
+                };
+                delete offer_params.publishDate;
+
+                const res = await request()
+                    .post("/offers/new")
+                    .send(withGodToken(offer_params));
+
+                expect(res.status).toBe(HTTPStatus.CONFLICT);
+                expect(res.body).toHaveProperty("error_code", ErrorTypes.VALIDATION_ERROR);
+                expect(res.body).toHaveProperty("errors");
+                expect(res.body.errors).toContainEqual(
+                    ValidationReasons.MAX_CONCURRENT_OFFERS_EXCEEDED(CompanyConstants.offers.max_concurrent));
+            });
         });
 
         describe("Trying to schedule an offer in a time period which reached the offers limit", () => {


### PR DESCRIPTION
Currently the default value for publishDate was being set on the offer service level, so validators that relied on it (such as the `verifyMaxConcurrentOffers`) behaved improperly when the user did not send this value (if it was undefined it could not calculate the concurrent offers).

Added a middleware that handles these cases and can be extended if needed in the future.