### PR TITLE
Add company logo to their Offers

### DIFF
--- a/.env
+++ b/.env
@@ -42,8 +42,8 @@ MAIL_FROM_PASSWORD=
 # Cloudinary API URL to save images
 CLOUDINARY_URL=
 
-# Local Webserver URL to save images
-WEBSERVER_HOST=https://ni.fe.up.pt/nijobs
+# Hostname of the application (where the webserver will be served) - without the trailing '/' 
+WEBSERVER_HOST=https://localhost/8087
 
 # Path to save file uploads, the path must be relative to the root of the project - Defaults to static
 UPLOAD_FOLDER=

--- a/.env
+++ b/.env
@@ -42,5 +42,8 @@ MAIL_FROM_PASSWORD=
 # Cloudinary API URL to save images
 CLOUDINARY_URL=
 
-# Path to save file uploads, the path must be relative to the root of the project - Defaults to public
+# Local Webserver URL to save images
+WEBSERVER_HOST=https://ni.fe.up.pt/nijobs
+
+# Path to save file uploads, the path must be relative to the root of the project - Defaults to static
 UPLOAD_FOLDER=

--- a/src/api/routes/company.js
+++ b/src/api/routes/company.js
@@ -1,3 +1,4 @@
+const config = require("../../config/env");
 const { Router } = require("express");
 
 const validators = require("../middleware/validators/company");
@@ -29,7 +30,7 @@ module.exports = (app) => {
             try {
                 const companyService = new CompanyService();
                 const { bio, contacts } = req.body;
-                const logo = req?.file?.url || `static/${req.file.filename}`;
+                const logo = req?.file?.url || `${config.webserver_host}/static/${req.file.filename}`;
                 const company_id = req.user.company;
                 await companyService.changeAttributes(company_id, { bio, contacts, logo, hasFinishedRegistration: true });
                 return res.json({});

--- a/src/config/env.js
+++ b/src/config/env.js
@@ -32,5 +32,6 @@ module.exports = Object.freeze({
 
     // File upload
     cloudinary_url: process.env.CLOUDINARY_URL,
-    upload_folder: path.join(path.join(__dirname, "../.."), process.env.UPLOAD_FOLDER || "static")
+    upload_folder: path.join(path.join(__dirname, "../.."), process.env.UPLOAD_FOLDER || "static"),
+    webserver_host: process.env.WEBSERVER_HOST,
 });

--- a/src/loaders/static.js
+++ b/src/loaders/static.js
@@ -3,6 +3,12 @@ const config = require("../config/env");
 const fs = require("fs");
 
 const setupStatic = (expressApp) => {
+    if (!(config.webserver_host)) {
+        console.error(`'WEBSERVER_HOST' must be specified in the env file! 
+        See README.md for details.`);
+        process.exit(125);
+    }
+
     const file_dir = config.upload_folder;
     if (!fs.existsSync(file_dir)) fs.mkdirSync(file_dir);
     expressApp.use("/static", express.static(file_dir));

--- a/src/loaders/static.js
+++ b/src/loaders/static.js
@@ -4,8 +4,7 @@ const fs = require("fs");
 
 const setupStatic = (expressApp) => {
     if (!(config.webserver_host)) {
-        console.error(`'WEBSERVER_HOST' must be specified in the env file! 
-        See README.md for details.`);
+        console.error("'WEBSERVER_HOST' must be specified in the env file!");
         process.exit(125);
     }
 

--- a/src/models/Company.js
+++ b/src/models/Company.js
@@ -30,7 +30,7 @@ const CompanySchema = new Schema({
 
 // Update offers from this company on name change
 CompanySchema.post("findOneAndUpdate", async function(doc) {
-    await Offer.updateMany({ owner: doc._id }, { ownerName: doc.name });
+    await Offer.updateMany({ owner: doc._id }, { ownerName: doc.name, ownerLogo: doc.logo });
 });
 
 // Delete Offers from the deleted Company (maybe we want to archive them instead?,

--- a/src/models/Offer.js
+++ b/src/models/Offer.js
@@ -6,7 +6,7 @@ const { FieldTypes, MIN_FIELDS, MAX_FIELDS } = require("./constants/FieldTypes")
 const { TechnologyTypes, MIN_TECHNOLOGIES, MAX_TECHNOLOGIES } = require("./constants/TechnologyTypes");
 const PointSchema = require("./Point");
 const { MONTH_IN_MS, OFFER_MAX_LIFETIME_MONTHS } = require("./constants/TimeConstants");
-const { noDuplicatesValidator, lengthBetweenValidator } = require("./modelUtils");
+const { noDuplicatesValidator, lengthBetweenValidator, validImageURL } = require("./modelUtils");
 const OfferConstants = require("./constants/Offer");
 const { concurrentOffersNotExceeded } = require("../api/middleware/validators/validatorUtils");
 
@@ -95,7 +95,7 @@ const OfferSchema = new Schema({
         ],
     },
     ownerName: { type: String, required: true },
-
+    ownerLogo: { type: String, required: true, validate: (val) => validImageURL(val) },
     location: { type: String, required: true },
     coordinates: { type: PointSchema, required: false },
 });
@@ -103,8 +103,8 @@ const OfferSchema = new Schema({
 OfferSchema.set("timestamps", true);
 
 OfferSchema.index(
-    { title: "text", ownerName: "text", jobType: "text", fields: "text", technologies: "text", location: "text" },
-    { name: "Search index", weights: { title: 10, ownerName: 5, jobType: 5, location: 5, fields: 5, technologies: 5 } }
+    { title: "text", ownerName: "text", jobType: "text", fields: "text", technologies: "text", location: "text", ownerLogo: "text" },
+    { name: "Search index", weights: { title: 10, ownerName: 5, jobType: 5, location: 5, fields: 5, technologies: 5, ownerLogo: 5 } }
 );
 
 // Checking if the publication date is less than or equal than the end date.

--- a/src/models/Offer.js
+++ b/src/models/Offer.js
@@ -103,8 +103,8 @@ const OfferSchema = new Schema({
 OfferSchema.set("timestamps", true);
 
 OfferSchema.index(
-    { title: "text", ownerName: "text", jobType: "text", fields: "text", technologies: "text", location: "text", ownerLogo: "text" },
-    { name: "Search index", weights: { title: 10, ownerName: 5, jobType: 5, location: 5, fields: 5, technologies: 5, ownerLogo: 5 } }
+    { title: "text", ownerName: "text", jobType: "text", fields: "text", technologies: "text", location: "text" },
+    { name: "Search index", weights: { title: 10, ownerName: 5, jobType: 5, location: 5, fields: 5, technologies: 5 } }
 );
 
 // Checking if the publication date is less than or equal than the end date.

--- a/src/models/modelUtils.js
+++ b/src/models/modelUtils.js
@@ -18,10 +18,17 @@ const lengthBetweenValidator = (val, min, max) => {
     return true;
 };
 
+const validImageURL = (val) => {
+    const regex = /^(https?:\/\/)(?:[a-z0-9-]+\.)+[a-z]{2,6}(?:\/[^/#?]+)+\.(?:jpe?g|png)$/;
+
+    return regex.test(val);
+};
+
 module.exports = {
     hasDuplicates,
     lengthBetween,
 
     noDuplicatesValidator,
     lengthBetweenValidator,
+    validImageURL,
 };

--- a/src/models/modelUtils.js
+++ b/src/models/modelUtils.js
@@ -19,7 +19,7 @@ const lengthBetweenValidator = (val, min, max) => {
 };
 
 const validImageURL = (val) => {
-    const regex = /^(https?:\/\/)(?:[a-z0-9-]+\.)+[a-z]{2,6}(?:\/[^/#?]+)+\.(?:jpe?g|png)$/;
+    const regex = /^(https?:\/\/)(?:[a-z0-9-]+\.)+[a-z]{2,6}(?:\/[^/#?]+)+/;
 
     return regex.test(val);
 };

--- a/src/services/offer.js
+++ b/src/services/offer.js
@@ -35,7 +35,9 @@ class OfferService {
         requirements,
     }) {
 
-        const ownerName = (await Company.findById(owner)).name;
+        const company = await Company.findById(owner);
+        const ownerName = company.name;
+        const ownerLogo = company.logo;
         const offer = await Offer.create({
             title,
             publishDate,
@@ -53,6 +55,7 @@ class OfferService {
             isHidden,
             owner,
             ownerName,
+            ownerLogo,
             location,
             coordinates,
             requirements

--- a/src/services/offer.js
+++ b/src/services/offer.js
@@ -35,9 +35,7 @@ class OfferService {
         requirements,
     }) {
 
-        const company = await Company.findById(owner);
-        const ownerName = company.name;
-        const ownerLogo = company.logo;
+        const { name: ownerName, logo: ownerLogo } = await Company.findById(owner);
         const offer = await Offer.create({
             title,
             publishDate,

--- a/test/company_schema.js
+++ b/test/company_schema.js
@@ -27,7 +27,8 @@ describe("# Company Schema tests", () => {
 
             beforeAll(async () => {
                 company = await Company.create({
-                    name: "first name"
+                    name: "first name",
+                    logo: "http://awebsite.com/alogo.jpg",
                 });
                 const offer = {
                     title: "Test Offer",
@@ -41,7 +42,8 @@ describe("# Company Schema tests", () => {
                     location: "Testing Street, Test City, 123",
                     requirements: ["The candidate must be tested", "Fluent in testJS"],
                     owner: company._id,
-                    ownerName: company.name
+                    ownerName: company.name,
+                    ownerLogo: company.logo,
                 };
 
                 await Offer.create([offer, offer]);

--- a/test/end-to-end/company.js
+++ b/test/end-to-end/company.js
@@ -1,3 +1,4 @@
+const config = require("../../src/config/env");
 const HTTPStatus = require("http-status-codes");
 const Account = require("../../src/models/Account");
 const Company = require("../../src/models/Company");
@@ -58,7 +59,7 @@ describe("Company application endpoint", () => {
             };
 
             const company_data = {
-                name: "Company Ltd"
+                name: "Company Ltd",
             };
 
             beforeEach(async () => {
@@ -86,7 +87,7 @@ describe("Company application endpoint", () => {
                 expect([...test_company.contacts]).toEqual(["contact1", "contact2"]);
                 expect(test_company.hasFinishedRegistration).toBe(true);
                 expect(test_company.bio).toBe("A very interesting and compelling bio");
-                const filename = path.join(__dirname, `../../${test_company.logo}`);
+                const filename = path.join(`${config.upload_folder}/${test_company.id}.png`);
                 expect(fs.existsSync(filename)).toBe(true);
 
                 await test_agent

--- a/test/end-to-end/offer.js
+++ b/test/end-to-end/offer.js
@@ -130,7 +130,8 @@ describe("Offer endpoint tests", () => {
                     expect(res.body).toHaveProperty("description", offer.description);
                     expect(res.body).toHaveProperty("location", offer.location);
                     expect(res.body).toHaveProperty("owner", test_company._id.toString());
-                    // TODO: When ownerName is a thing -> expect(res.body).toHaveProperty("ownerName", test_company.name);
+                    expect(res.body).toHaveProperty("ownerName", test_company.name);
+                    expect(res.body).toHaveProperty("ownerLogo", test_company.logo);
                 });
             });
 
@@ -334,8 +335,6 @@ describe("Offer endpoint tests", () => {
                 const offer_params = {
                     ...offer,
                     owner: test_company._id,
-                    ownerName: test_company.name,
-                    ownerLogo: test_company.logo,
                 };
 
                 const res = await request()
@@ -353,6 +352,8 @@ describe("Offer endpoint tests", () => {
                 expect(created_offer).toHaveProperty("title", offer.title);
                 expect(created_offer).toHaveProperty("description", offer.description);
                 expect(created_offer).toHaveProperty("location", offer.location);
+                expect(created_offer).toHaveProperty("ownerName", test_company.name);
+                expect(created_offer).toHaveProperty("ownerLogo", test_company.logo);
             });
         });
 
@@ -388,8 +389,6 @@ describe("Offer endpoint tests", () => {
                 const offer_params = {
                     ...generateTestOffer(),
                     owner: test_company._id,
-                    ownerName: test_company.name,
-                    ownerLogo: test_company.logo,
                 };
 
                 const res = await request()
@@ -400,6 +399,8 @@ describe("Offer endpoint tests", () => {
                 expect(res.body).toHaveProperty("title", offer_params.title);
                 expect(res.body).toHaveProperty("description", offer_params.description);
                 expect(res.body).toHaveProperty("location", offer_params.location);
+                expect(res.body).toHaveProperty("ownerName", test_company.name);
+                expect(res.body).toHaveProperty("ownerLogo", test_company.logo);
             });
         });
 
@@ -431,8 +432,6 @@ describe("Offer endpoint tests", () => {
                 const offer_params = {
                     ...generateTestOffer(),
                     owner: test_company._id,
-                    ownerName: test_company.name,
-                    ownerLogo: test_company.logo,
                 };
 
                 const res = await request()
@@ -450,8 +449,6 @@ describe("Offer endpoint tests", () => {
                 const offer_params = {
                     ...generateTestOffer(),
                     owner: test_company._id,
-                    ownerName: test_company.name,
-                    ownerLogo: test_company.logo,
                 };
                 delete offer_params.publishDate;
 
@@ -497,8 +494,6 @@ describe("Offer endpoint tests", () => {
                         "publishEndDate": (new Date(Date.now() + (5 * DAY_TO_MS))).toISOString()
                     }),
                     owner: test_company._id,
-                    ownerName: test_company.name,
-                    ownerLogo: test_company.logo,
                 };
 
                 const res = await request()
@@ -548,8 +543,6 @@ describe("Offer endpoint tests", () => {
                     "publishDate": (new Date(Date.now() + (4 * DAY_TO_MS))).toISOString(),
                     "publishEndDate": (new Date(Date.now() + (9 * DAY_TO_MS))).toISOString(),
                     owner: test_company._id,
-                    ownerName: test_company.name,
-                    ownerLogo: test_company.logo,
                 });
 
                 const res = await request()
@@ -593,6 +586,8 @@ describe("Offer endpoint tests", () => {
                 expect(created_offer).toHaveProperty("description", offer.description);
                 expect(created_offer).toHaveProperty("location", offer.location);
                 expect(created_offer).toHaveProperty("publishDate");
+                expect(created_offer).toHaveProperty("ownerName", test_company.name);
+                expect(created_offer).toHaveProperty("ownerLogo", test_company.logo);
             });
         });
 
@@ -602,8 +597,6 @@ describe("Offer endpoint tests", () => {
                     jobMinDuration: 10,
                     jobMaxDuration: 8,
                     owner: test_company._id,
-                    ownerName: test_company.name,
-                    ownerLogo: test_company.logo,
                 });
 
                 const res = await request()
@@ -622,8 +615,6 @@ describe("Offer endpoint tests", () => {
                     jobMinDuration: 8,
                     jobMaxDuration: 10,
                     owner: test_company._id,
-                    ownerName: test_company.name,
-                    ownerLogo: test_company.logo,
                 });
 
                 const res = await request()
@@ -637,8 +628,6 @@ describe("Offer endpoint tests", () => {
                 const offer_params = generateTestOffer({
                     jobMaxDuration: 8,
                     owner: test_company._id,
-                    ownerName: test_company.name,
-                    ownerLogo: test_company.logo,
                 });
 
                 const res = await request()
@@ -656,8 +645,6 @@ describe("Offer endpoint tests", () => {
                 const offer_params = generateTestOffer({
                     jobMinDuration: 8,
                     owner: test_company._id,
-                    ownerName: test_company.name,
-                    ownerLogo: test_company.logo,
                 });
 
                 const res = await request()
@@ -689,7 +676,7 @@ describe("Offer endpoint tests", () => {
                     ...generateTestOffer(),
                     owner: incomplete_test_company._id,
                     ownerName: incomplete_test_company.name,
-                    ownerLogo: test_company.logo,
+                    ownerLogo: incomplete_test_company.logo,
                 };
 
                 const res = await request()

--- a/test/end-to-end/offer.js
+++ b/test/end-to-end/offer.js
@@ -62,7 +62,8 @@ describe("Offer endpoint tests", () => {
             name: "test company",
             bio: "a bio",
             contacts: ["a contact"],
-            hasFinishedRegistration: true
+            hasFinishedRegistration: true,
+            logo: "http://awebsite.com/alogo.jpg",
         });
         await Account.deleteMany({});
         await Account.create({
@@ -305,6 +306,7 @@ describe("Offer endpoint tests", () => {
                     ...offer,
                     owner: test_company._id,
                     ownerName: test_company.name,
+                    ownerLogo: test_company.logo,
                     publishDate: publishDate.toISOString(),
                     publishEndDate: (new Date(publishDate.getTime() + (MONTH_IN_MS * OFFER_MAX_LIFETIME_MONTHS) + DAY_TO_MS)).toISOString(),
                 };
@@ -332,7 +334,8 @@ describe("Offer endpoint tests", () => {
                 const offer_params = {
                     ...offer,
                     owner: test_company._id,
-                    ownerName: test_company.name
+                    ownerName: test_company.name,
+                    ownerLogo: test_company.logo,
                 };
 
                 const res = await request()
@@ -371,6 +374,7 @@ describe("Offer endpoint tests", () => {
                 testOffers.forEach((offer) => {
                     offer.owner = test_company._id;
                     offer.ownerName = test_company.name;
+                    offer.ownerLogo = test_company.logo;
                 });
 
                 await Offer.create(testOffers);
@@ -385,6 +389,7 @@ describe("Offer endpoint tests", () => {
                     ...generateTestOffer(),
                     owner: test_company._id,
                     ownerName: test_company.name,
+                    ownerLogo: test_company.logo,
                 };
 
                 const res = await request()
@@ -411,6 +416,7 @@ describe("Offer endpoint tests", () => {
                 testOffers.forEach((offer) => {
                     offer.owner = test_company._id;
                     offer.ownerName = test_company.name;
+                    offer.ownerLogo = test_company.logo;
                 });
 
                 await Offer.create(testOffers);
@@ -426,6 +432,7 @@ describe("Offer endpoint tests", () => {
                     ...generateTestOffer(),
                     owner: test_company._id,
                     ownerName: test_company.name,
+                    ownerLogo: test_company.logo,
                 };
 
                 const res = await request()
@@ -444,6 +451,7 @@ describe("Offer endpoint tests", () => {
                     ...generateTestOffer(),
                     owner: test_company._id,
                     ownerName: test_company.name,
+                    ownerLogo: test_company.logo,
                 };
                 delete offer_params.publishDate;
 
@@ -472,6 +480,7 @@ describe("Offer endpoint tests", () => {
                 testOffers.forEach((offer) => {
                     offer.owner = test_company._id;
                     offer.ownerName = test_company.name;
+                    offer.ownerLogo = test_company.logo;
                 });
 
                 await Offer.create(testOffers);
@@ -488,7 +497,8 @@ describe("Offer endpoint tests", () => {
                         "publishEndDate": (new Date(Date.now() + (5 * DAY_TO_MS))).toISOString()
                     }),
                     owner: test_company._id,
-                    ownerName: test_company.name
+                    ownerName: test_company.name,
+                    ownerLogo: test_company.logo,
                 };
 
                 const res = await request()
@@ -527,6 +537,7 @@ describe("Offer endpoint tests", () => {
                 testOffers.forEach((offer) => {
                     offer.owner = test_company._id;
                     offer.ownerName = test_company.name;
+                    offer.ownerLogo = test_company.logo;
                 });
 
                 await Offer.create(testOffers);
@@ -537,7 +548,8 @@ describe("Offer endpoint tests", () => {
                     "publishDate": (new Date(Date.now() + (4 * DAY_TO_MS))).toISOString(),
                     "publishEndDate": (new Date(Date.now() + (9 * DAY_TO_MS))).toISOString(),
                     owner: test_company._id,
-                    ownerName: test_company.name
+                    ownerName: test_company.name,
+                    ownerLogo: test_company.logo,
                 });
 
                 const res = await request()
@@ -562,6 +574,7 @@ describe("Offer endpoint tests", () => {
                     technologies: ["React", "CSS"],
                     owner: test_company._id,
                     ownerName: test_company.name,
+                    ownerLogo: test_company.logo,
                     location: "Testing Street, Test City, 123",
                     requirements: ["The candidate must be tested", "Fluent in testJS"],
                 };
@@ -590,6 +603,7 @@ describe("Offer endpoint tests", () => {
                     jobMaxDuration: 8,
                     owner: test_company._id,
                     ownerName: test_company.name,
+                    ownerLogo: test_company.logo,
                 });
 
                 const res = await request()
@@ -609,6 +623,7 @@ describe("Offer endpoint tests", () => {
                     jobMaxDuration: 10,
                     owner: test_company._id,
                     ownerName: test_company.name,
+                    ownerLogo: test_company.logo,
                 });
 
                 const res = await request()
@@ -623,6 +638,7 @@ describe("Offer endpoint tests", () => {
                     jobMaxDuration: 8,
                     owner: test_company._id,
                     ownerName: test_company.name,
+                    ownerLogo: test_company.logo,
                 });
 
                 const res = await request()
@@ -641,6 +657,7 @@ describe("Offer endpoint tests", () => {
                     jobMinDuration: 8,
                     owner: test_company._id,
                     ownerName: test_company.name,
+                    ownerLogo: test_company.logo,
                 });
 
                 const res = await request()
@@ -658,7 +675,8 @@ describe("Offer endpoint tests", () => {
                     name: "incomplete test company",
                     bio: "a bio",
                     contacts: ["a contact"],
-                    hasFinishedRegistration: false
+                    hasFinishedRegistration: false,
+                    logo: "http://awebsite.com/alogo.jpg",
                 });
             });
 
@@ -671,6 +689,7 @@ describe("Offer endpoint tests", () => {
                     ...generateTestOffer(),
                     owner: incomplete_test_company._id,
                     ownerName: incomplete_test_company.name,
+                    ownerLogo: test_company.logo,
                 };
 
                 const res = await request()
@@ -735,7 +754,8 @@ describe("Offer endpoint tests", () => {
                 test_company = await Company.create({
                     name: "test company",
                     bio: "a bio",
-                    contacts: ["a contact"]
+                    contacts: ["a contact"],
+                    logo: "http://awebsite.com/alogo.jpg",
                 });
 
                 test_offer = {
@@ -745,6 +765,7 @@ describe("Offer endpoint tests", () => {
                     }),
                     owner: test_company._id,
                     ownerName: test_company.name,
+                    ownerLogo: test_company.logo,
                 };
 
                 await Offer.deleteMany({});
@@ -779,6 +800,7 @@ describe("Offer endpoint tests", () => {
                         .forEach((offer) => {
                             offer.owner = test_company._id;
                             offer.ownerName = test_company.name;
+                            offer.ownerLogo = test_company.logo;
                         });
 
                     await Offer.create([expired_test_offer, future_test_offer]);
@@ -1295,15 +1317,17 @@ describe("Offer endpoint tests", () => {
                 await Offer.deleteMany({});
 
                 const createOffer = async (offer) => {
-                    const { _id, owner, ownerName } = await Offer.create({
+                    const { _id, owner, ownerName, ownerLogo } = await Offer.create({
                         ...offer,
                         owner: test_company._id.toString(),
                         ownerName: test_company.name,
+                        ownerLogo: test_company.logo,
                     });
                     return {
                         ...offer,
                         owner: owner.toString(),
                         ownerName,
+                        ownerLogo,
                         _id: _id.toString()
                     };
                 };
@@ -1378,15 +1402,17 @@ describe("Offer endpoint tests", () => {
             await Offer.deleteMany({});
             await test_agent.del("/auth/login");
             createOffer = async (offer) => {
-                const { _id, owner, ownerName, jobMinDuration, jobMaxDuration, createdAt } = await Offer.create({
+                const { _id, owner, ownerName, ownerLogo, jobMinDuration, jobMaxDuration, createdAt } = await Offer.create({
                     ...offer,
                     owner: test_company._id.toString(),
                     ownerName: test_company.name,
+                    ownerLogo: test_company.logo,
                 });
                 return {
                     ...offer,
                     owner: owner.toString(),
                     ownerName,
+                    ownerLogo,
                     _id: _id.toString(),
                     jobMinDuration,
                     jobMaxDuration,
@@ -1844,6 +1870,7 @@ describe("Offer endpoint tests", () => {
                 ...generateTestOffer({
                     owner: test_company._id.toString(),
                     ownerName: test_company.name,
+                    ownerLogo: test_company.logo,
                 }),
             });
 
@@ -1851,6 +1878,7 @@ describe("Offer endpoint tests", () => {
                 ...generateTestOffer({
                     owner: test_company._id.toString(),
                     ownerName: test_company.name,
+                    ownerLogo: test_company.logo,
                 }),
             });
 
@@ -1859,6 +1887,7 @@ describe("Offer endpoint tests", () => {
                     isHidden: true,
                     owner: test_company._id.toString(),
                     ownerName: test_company.name,
+                    ownerLogo: test_company.logo,
                 }),
             });
 
@@ -1866,12 +1895,14 @@ describe("Offer endpoint tests", () => {
                 ...generateTestOffer(),
                 owner: test_company._id.toString(),
                 ownerName: test_company.name,
+                ownerLogo: test_company.logo,
             });
 
             email_test_offer = await Offer.create({
                 ...generateTestOffer(),
                 owner: test_company._id.toString(),
                 ownerName: test_company.name,
+                ownerLogo: test_company.logo,
             });
 
             await (new OfferService()).disable(hidden_user_test_offer._id, OfferConstants.HiddenOfferReasons.COMPANY_REQUEST);
@@ -2042,7 +2073,8 @@ describe("Offer endpoint tests", () => {
             test_company_2 = await Company.create({
                 name: "test company",
                 bio: "a bio",
-                contacts: ["a contact"]
+                contacts: ["a contact"],
+                logo: "http://awebsite.com/alogo.jpg",
             });
             await Account.create({
                 email: test_user_company_2.email,
@@ -2054,6 +2086,7 @@ describe("Offer endpoint tests", () => {
                 ...generateTestOffer({
                     owner: test_company._id.toString(),
                     ownerName: test_company.name,
+                    ownerLogo: test_company.logo,
                 }),
             });
 
@@ -2061,6 +2094,7 @@ describe("Offer endpoint tests", () => {
                 ...generateTestOffer({
                     owner: test_company._id.toString(),
                     ownerName: test_company.name,
+                    ownerLogo: test_company.logo,
                 }),
             });
 
@@ -2070,6 +2104,7 @@ describe("Offer endpoint tests", () => {
                     isHidden: true,
                     owner: test_company._id.toString(),
                     ownerName: test_company.name,
+                    ownerLogo: test_company.logo,
                 }),
             });
 
@@ -2077,6 +2112,7 @@ describe("Offer endpoint tests", () => {
                 ...generateTestOffer({
                     owner: test_company._id.toString(),
                     ownerName: test_company.name,
+                    ownerLogo: test_company.logo,
                 }),
             });
 
@@ -2177,6 +2213,7 @@ describe("Offer endpoint tests", () => {
                 ...generateTestOffer({
                     owner: test_company._id.toString(),
                     ownerName: test_company.name,
+                    ownerLogo: test_company.logo,
                 }),
             });
 
@@ -2185,6 +2222,7 @@ describe("Offer endpoint tests", () => {
                     isHidden: true,
                     owner: test_company._id.toString(),
                     ownerName: test_company.name,
+                    ownerLogo: test_company.logo,
                 }),
             });
 
@@ -2193,6 +2231,7 @@ describe("Offer endpoint tests", () => {
                     isHidden: true,
                     owner: test_company._id.toString(),
                     ownerName: test_company.name,
+                    ownerLogo: test_company.logo,
                 }),
             });
 
@@ -2204,6 +2243,7 @@ describe("Offer endpoint tests", () => {
                     "publishEndDate": (new Date(Date.now() + (20 * DAY_TO_MS))).toISOString(),
                     owner: test_company._id.toString(),
                     ownerName: test_company.name,
+                    ownerLogo: test_company.logo,
                 }),
             });
 
@@ -2272,6 +2312,7 @@ describe("Offer endpoint tests", () => {
                 test_offers.forEach((offer) => {
                     offer.owner = test_company._id;
                     offer.ownerName = test_company.name;
+                    offer.ownerLogo = test_company.logo;
                 });
 
                 test_offer = await Offer.create({
@@ -2279,6 +2320,7 @@ describe("Offer endpoint tests", () => {
                         isHidden: true,
                         owner: test_company._id,
                         ownerName: test_company.name,
+                        ownerLogo: test_company.logo,
                     }),
                 });
 

--- a/test/offer_schema.js
+++ b/test/offer_schema.js
@@ -95,6 +95,17 @@ describe("# Offer Schema tests", () => {
                 }
             });
 
+            test("'ownerLogo' is required", async () => {
+                const offer = new Offer({});
+                try {
+                    await offer.validate();
+                } catch (err) {
+                    expect(err.errors.ownerLogo).toBeDefined();
+                    expect(err.errors.ownerLogo).toHaveProperty("kind", "required");
+                    expect(err.errors.ownerLogo).toHaveProperty("message", "Path `ownerLogo` is required.");
+                }
+            });
+
             test("'location' is required", async () => {
                 const offer = new Offer({});
                 try {


### PR DESCRIPTION
Closes #128 

Added `ownerLogo` param to *Offer* when creating, since the name is already being retrieved to the *Company* model.
*Company* logo will have a URL associated, so a .env variable was created to support local development (since the images will be stored in Cloudinary, in production).
Added some tests to check that the `ownerLogo` is validated and fixed all tests related to *Offer* and *Company* affected by this feature.