### PR TITLE
Validating max image size on Company Registration Finish

### DIFF
--- a/src/api/middleware/files.js
+++ b/src/api/middleware/files.js
@@ -9,6 +9,7 @@ const cloudinary = require("cloudinary").v2;
 const config = require("../../config/env");
 const ValidationReasons = require("./validators/validationReasons");
 
+const { MAX_FILE_SIZE } = require("./utils");
 const parseError = (message) => message.toLowerCase().replace(/ /g, "-");
 
 const parseSingleFile = (field_name) => (req, res, next) => {
@@ -20,6 +21,10 @@ const parseSingleFile = (field_name) => (req, res, next) => {
             if (error) {
                 message = error instanceof MulterError ?
                     parseError(error.message) : error.message;
+
+                if (error.code === "LIMIT_FILE_SIZE")
+                    message = ValidationReasons.FILE_TOO_LARGE(MAX_FILE_SIZE);
+
                 param = error.field ? error.field : param;
             }
             return next(new APIError(

--- a/src/api/middleware/files.js
+++ b/src/api/middleware/files.js
@@ -9,7 +9,7 @@ const cloudinary = require("cloudinary").v2;
 const config = require("../../config/env");
 const ValidationReasons = require("./validators/validationReasons");
 
-const { MAX_FILE_SIZE } = require("./utils");
+const { MAX_FILE_SIZE_MB } = require("./utils");
 const parseError = (message) => message.toLowerCase().replace(/ /g, "-");
 
 const parseSingleFile = (field_name) => (req, res, next) => {
@@ -23,7 +23,7 @@ const parseSingleFile = (field_name) => (req, res, next) => {
                     parseError(error.message) : error.message;
 
                 if (error.code === "LIMIT_FILE_SIZE")
-                    message = ValidationReasons.FILE_TOO_LARGE(MAX_FILE_SIZE);
+                    message = ValidationReasons.FILE_TOO_LARGE(MAX_FILE_SIZE_MB);
 
                 param = error.field ? error.field : param;
             }

--- a/src/api/middleware/files.js
+++ b/src/api/middleware/files.js
@@ -9,7 +9,7 @@ const cloudinary = require("cloudinary").v2;
 const config = require("../../config/env");
 const ValidationReasons = require("./validators/validationReasons");
 
-const parseError = (message) => message.toLowerCase().replace(" ", "-");
+const parseError = (message) => message.toLowerCase().replaceAll(" ", "-");
 
 const parseSingleFile = (field_name) => (req, res, next) => {
     const upload = multerConfig.single(field_name);

--- a/src/api/middleware/files.js
+++ b/src/api/middleware/files.js
@@ -9,7 +9,7 @@ const cloudinary = require("cloudinary").v2;
 const config = require("../../config/env");
 const ValidationReasons = require("./validators/validationReasons");
 
-const parseError = (message) => message.toLowerCase().replaceAll(" ", "-");
+const parseError = (message) => message.toLowerCase().replace(/ /g, "-");
 
 const parseSingleFile = (field_name) => (req, res, next) => {
     const upload = multerConfig.single(field_name);

--- a/src/api/middleware/utils.js
+++ b/src/api/middleware/utils.js
@@ -6,6 +6,7 @@ const lodash = require("lodash");
 const DEFAULT_ERROR_CODE = ErrorTypes.VALIDATION_ERROR;
 const DEFAULT_ERROR_MSG = ValidationReasons.UNKNOWN;
 const DEFAULT_STATUS_CODE = HTTPStatus.BAD_REQUEST;
+const MAX_FILE_SIZE = 10; // MB
 
 /**
  * Combines array of middleware using OR logic. Only fails if ALL functions fail (either by throwing or calling next(error))
@@ -86,5 +87,6 @@ module.exports = {
     when,
     DEFAULT_ERROR_CODE,
     DEFAULT_ERROR_MSG,
-    DEFAULT_STATUS_CODE
+    DEFAULT_STATUS_CODE,
+    MAX_FILE_SIZE
 };

--- a/src/api/middleware/utils.js
+++ b/src/api/middleware/utils.js
@@ -6,7 +6,7 @@ const lodash = require("lodash");
 const DEFAULT_ERROR_CODE = ErrorTypes.VALIDATION_ERROR;
 const DEFAULT_ERROR_MSG = ValidationReasons.UNKNOWN;
 const DEFAULT_STATUS_CODE = HTTPStatus.BAD_REQUEST;
-const MAX_FILE_SIZE = 10; // MB
+const MAX_FILE_SIZE_MB = 10;
 
 /**
  * Combines array of middleware using OR logic. Only fails if ALL functions fail (either by throwing or calling next(error))
@@ -88,5 +88,5 @@ module.exports = {
     DEFAULT_ERROR_CODE,
     DEFAULT_ERROR_MSG,
     DEFAULT_STATUS_CODE,
-    MAX_FILE_SIZE
+    MAX_FILE_SIZE_MB
 };

--- a/src/api/middleware/validators/validationReasons.js
+++ b/src/api/middleware/validators/validationReasons.js
@@ -42,7 +42,7 @@ const ValidationReasons = Object.freeze({
     IMAGE_FORMAT: "formats-supported-png-jpeg-jpg",
     OFFER_BLOCKED_ADMIN: "offer-blocked-by-admin",
     OFFER_HIDDEN: "offer-is-hidden",
-    FILE_TOO_LARGE: (max) => `file-cant-be-larger-than-${max}mb`,
+    FILE_TOO_LARGE: (max) => `file-cant-be-larger-than-${max}MB`,
 });
 
 module.exports = ValidationReasons;

--- a/src/api/middleware/validators/validationReasons.js
+++ b/src/api/middleware/validators/validationReasons.js
@@ -42,6 +42,7 @@ const ValidationReasons = Object.freeze({
     IMAGE_FORMAT: "formats-supported-png-jpeg-jpg",
     OFFER_BLOCKED_ADMIN: "offer-blocked-by-admin",
     OFFER_HIDDEN: "offer-is-hidden",
+    FILE_TOO_LARGE: (max) => `file-cant-be-larger-than-${max}mb`,
 });
 
 module.exports = ValidationReasons;

--- a/src/config/multer.js
+++ b/src/config/multer.js
@@ -2,7 +2,7 @@ const multer = require("multer");
 const ValidationReasons = require("../api/middleware/validators/validationReasons");
 
 const storage =  multer.memoryStorage();
-const limits = { fileSize: 5000000 };
+const limits = { fileSize: 10485760 };
 const fileFilter = (req, file, cb) => {
     const fileTypes = /png|jpeg|jpg/;
     const mimeType = fileTypes.test(file.mimetype);

--- a/src/config/multer.js
+++ b/src/config/multer.js
@@ -1,9 +1,9 @@
 const multer = require("multer");
 const ValidationReasons = require("../api/middleware/validators/validationReasons");
-const { MAX_FILE_SIZE } = require("../api/middleware/utils");
+const { MAX_FILE_SIZE_MB } = require("../api/middleware/utils");
 
 const storage =  multer.memoryStorage();
-const limits = { fileSize: MAX_FILE_SIZE * 1024 * 1024 };
+const limits = { fileSize: MAX_FILE_SIZE_MB * 1024 * 1024 };
 const fileFilter = (req, file, cb) => {
     const fileTypes = /png|jpeg|jpg/;
     const mimeType = fileTypes.test(file.mimetype);

--- a/src/config/multer.js
+++ b/src/config/multer.js
@@ -1,8 +1,9 @@
 const multer = require("multer");
 const ValidationReasons = require("../api/middleware/validators/validationReasons");
+const { MAX_FILE_SIZE } = require("../api/middleware/utils");
 
 const storage =  multer.memoryStorage();
-const limits = { fileSize: 10485760 };
+const limits = { fileSize: MAX_FILE_SIZE * 1024 * 1024 };
 const fileFilter = (req, file, cb) => {
     const fileTypes = /png|jpeg|jpg/;
     const mimeType = fileTypes.test(file.mimetype);

--- a/test/end-to-end/company.js
+++ b/test/end-to-end/company.js
@@ -213,6 +213,19 @@ describe("Company application endpoint", () => {
                     });
                 });
 
+                test("should return an error when the image size is greater than the max size", async () => {
+                    const res = await test_agent
+                        .post("/company/application/finish")
+                        .attach("logo", "test/data/logo-niaefeup-10mb.png")
+                        .expect(HTTPStatus.UNPROCESSABLE_ENTITY);
+
+                    expect(res.body.errors).toContainEqual({
+                        "location": "body",
+                        "msg": "file-too-large",
+                        "param": "logo",
+                    });
+                });
+
             });
 
             describe("bio", () => {

--- a/test/end-to-end/company.js
+++ b/test/end-to-end/company.js
@@ -11,6 +11,7 @@ const { ErrorTypes } = require("../../src/api/middleware/errorHandler");
 const withGodToken = require("../utils/GodToken");
 const EmailService = require("../../src/lib/emailService");
 const { COMPANY_UNBLOCKED_NOTIFICATION, COMPANY_BLOCKED_NOTIFICATION } = require("../../src/email-templates/companyManagement");
+const { MAX_FILE_SIZE_MB } = require("../../src/api/middleware/utils");
 
 const getCompanies = async (options) =>
     [...(await Company.find(options))]
@@ -221,7 +222,7 @@ describe("Company application endpoint", () => {
 
                     expect(res.body.errors).toContainEqual({
                         "location": "body",
-                        "msg": "file-cant-be-larger-than-10mb",
+                        "msg": ValidationReasons.FILE_TOO_LARGE(MAX_FILE_SIZE_MB),
                         "param": "logo",
                     });
                 });

--- a/test/end-to-end/company.js
+++ b/test/end-to-end/company.js
@@ -221,7 +221,7 @@ describe("Company application endpoint", () => {
 
                     expect(res.body.errors).toContainEqual({
                         "location": "body",
-                        "msg": "file-too-large",
+                        "msg": "file-cant-be-larger-than-10mb",
                         "param": "logo",
                     });
                 });


### PR DESCRIPTION
closes #150 

The easiest way I found to solve the problem, since we're already using multer, was to change the fileSize in the limits to 10MB and then change the error message to fit the format we've been using (with all lowercase and hyphens). Is this what was intended? Or do you think we should at least give a longer explanation in the message?