### PR TITLE
Unify error messages

### DIFF
--- a/src/api/middleware/errorHandler.js
+++ b/src/api/middleware/errorHandler.js
@@ -12,7 +12,7 @@ class APIError extends Error {
     constructor(status_code, error_code, info, payload) {
         super(info);
         // info: array of errors or error message
-        this.errors = Array.isArray(info) ? info : ensureArray({ msg: info });
+        this.errors = Array.isArray(info) ? info : [{ msg: info }];
         this.status_code = status_code;
         this.error_code = error_code;
         this.payload = payload;

--- a/src/api/middleware/errorHandler.js
+++ b/src/api/middleware/errorHandler.js
@@ -9,9 +9,10 @@ const buildErrorResponse = (error_code, errors) => ({
 });
 
 class APIError extends Error {
-    constructor(status_code, error_code, msg, payload) {
-        super(msg);
-        this.errors = ensureArray(msg);
+    constructor(status_code, error_code, info, payload) {
+        super(info);
+        // info: array of errors or error message
+        this.errors = Array.isArray(info) ? info : ensureArray({ msg: info });
         this.status_code = status_code;
         this.error_code = error_code;
         this.payload = payload;

--- a/src/api/routes/example.js
+++ b/src/api/routes/example.js
@@ -1,7 +1,7 @@
 const HTTPStatus = require("http-status-codes");
 const { Router } = require("express");
 
-const { ErrorTypes, APIError } = require("../middleware/errorHandler");
+const { ErrorTypes, APIError, buildErrorResponse } = require("../middleware/errorHandler");
 const ExampleUser = require("../../models/ExampleUser");
 const { or } = require("../middleware/utils");
 
@@ -46,10 +46,9 @@ module.exports = (app) => {
             });
 
         } catch (err) {
-            return res.status(HTTPStatus.INTERNAL_SERVER_ERROR).json({
-                "reason": "dunno",
-                "error_code": ErrorTypes.DB_ERROR,
-            });
+            return res
+                .status(HTTPStatus.INTERNAL_SERVER_ERROR)
+                .json(buildErrorResponse(ErrorTypes.DB_ERROR, ["dunno"]));
         }
     });
 
@@ -58,10 +57,9 @@ module.exports = (app) => {
      */
     router.post("/", async (req, res) => {
         if (!req.body.username) {
-            return res.status(HTTPStatus.BAD_REQUEST).json({
-                "reason": "No username specified",
-                "error_code": ErrorTypes.MISSING_FIELD,
-            });
+            return res
+                .status(HTTPStatus.BAD_REQUEST)
+                .json(buildErrorResponse(ErrorTypes.MISSING_FIELD, ["No username specified"]));
         }
 
         // Inserting user into db and replying with success or not
@@ -74,10 +72,9 @@ module.exports = (app) => {
 
             return res.status(HTTPStatus.OK).json({});
         } catch (err) {
-            return res.status(HTTPStatus.INTERNAL_SERVER_ERROR).json({
-                "reason": "dunno2",
-                "error_code": ErrorTypes.DB_ERROR,
-            });
+            return res
+                .status(HTTPStatus.INTERNAL_SERVER_ERROR)
+                .json(buildErrorResponse(ErrorTypes.DB_ERROR, ["dunno2"]));
         }
     });
 };

--- a/src/api/routes/example.js
+++ b/src/api/routes/example.js
@@ -48,7 +48,7 @@ module.exports = (app) => {
         } catch (err) {
             return res
                 .status(HTTPStatus.INTERNAL_SERVER_ERROR)
-                .json(buildErrorResponse(ErrorTypes.DB_ERROR, ["dunno"]));
+                .json(buildErrorResponse(ErrorTypes.DB_ERROR, [{ msg: "dunno" }]));
         }
     });
 
@@ -59,7 +59,7 @@ module.exports = (app) => {
         if (!req.body.username) {
             return res
                 .status(HTTPStatus.BAD_REQUEST)
-                .json(buildErrorResponse(ErrorTypes.MISSING_FIELD, ["No username specified"]));
+                .json(buildErrorResponse(ErrorTypes.MISSING_FIELD, [{ msg: "No username specified" }]));
         }
 
         // Inserting user into db and replying with success or not
@@ -74,7 +74,7 @@ module.exports = (app) => {
         } catch (err) {
             return res
                 .status(HTTPStatus.INTERNAL_SERVER_ERROR)
-                .json(buildErrorResponse(ErrorTypes.DB_ERROR, ["dunno2"]));
+                .json(buildErrorResponse(ErrorTypes.DB_ERROR, [{ msg: "dunno2" }]));
         }
     });
 };

--- a/src/api/routes/review.js
+++ b/src/api/routes/review.js
@@ -84,14 +84,14 @@ module.exports = (app) => {
                 if (err instanceof ApplicationService.CompanyApplicationNotFound) {
                     return res
                         .status(HTTPStatus.NOT_FOUND)
-                        .json(buildErrorResponse(ErrorTypes.VALIDATION_ERROR, [err.message]));
+                        .json(buildErrorResponse(ErrorTypes.VALIDATION_ERROR, [{ msg: err.message }]));
                 } else if (
                     err instanceof ApplicationService.CompanyApplicationAlreadyReiewed ||
                     err instanceof ApplicationService.CompanyApplicationEmailAlreadyInUse
                 ) {
                     return res
                         .status(HTTPStatus.CONFLICT)
-                        .json(buildErrorResponse(ErrorTypes.VALIDATION_ERROR, [err.message]));
+                        .json(buildErrorResponse(ErrorTypes.VALIDATION_ERROR, [{ msg: err.message }]));
                 } else {
                     return next(err);
                 }
@@ -114,11 +114,11 @@ module.exports = (app) => {
                 if (err instanceof ApplicationService.CompanyApplicationNotFound) {
                     return res
                         .status(HTTPStatus.NOT_FOUND)
-                        .json(buildErrorResponse(ErrorTypes.VALIDATION_ERROR, [err.message]));
+                        .json(buildErrorResponse(ErrorTypes.VALIDATION_ERROR, [{ msg: err.message }]));
                 } else if (err instanceof ApplicationService.CompanyApplicationAlreadyReiewed) {
                     return res
                         .status(HTTPStatus.CONFLICT)
-                        .json(buildErrorResponse(ErrorTypes.VALIDATION_ERROR, [err.message]));
+                        .json(buildErrorResponse(ErrorTypes.VALIDATION_ERROR, [{ msg: err.message }]));
                 } else {
                     return next(err);
                 }

--- a/test/end-to-end/company.js
+++ b/test/end-to-end/company.js
@@ -149,7 +149,7 @@ describe("Company application endpoint", () => {
                     .expect(HTTPStatus.FORBIDDEN);
 
                 expect(res.body.errors).toContainEqual(
-                    ValidationReasons.REGISTRATION_FINISHED
+                    { msg: ValidationReasons.REGISTRATION_FINISHED }
                 );
 
                 // clean up file created
@@ -179,7 +179,7 @@ describe("Company application endpoint", () => {
                     .expect(HTTPStatus.FORBIDDEN);
 
                 expect(res.body.errors).toContainEqual(
-                    ValidationReasons.REGISTRATION_FINISHED
+                    { msg: ValidationReasons.REGISTRATION_FINISHED }
                 );
 
                 // clean up file created

--- a/test/end-to-end/company.js
+++ b/test/end-to-end/company.js
@@ -344,7 +344,7 @@ describe("Company application endpoint", () => {
                 .expect(HTTPStatus.UNAUTHORIZED);
             expect(res.body).toHaveProperty("error_code", ErrorTypes.FORBIDDEN);
             expect(res.body).toHaveProperty("errors");
-            expect(res.body.errors).toContainEqual(ValidationReasons.INSUFFICIENT_PERMISSIONS);
+            expect(res.body.errors[0]).toHaveProperty("msg", ValidationReasons.INSUFFICIENT_PERMISSIONS);
         });
 
         test("should fail if logged in as company", async () => {
@@ -358,7 +358,7 @@ describe("Company application endpoint", () => {
                 .expect(HTTPStatus.UNAUTHORIZED);
             expect(res.body).toHaveProperty("error_code", ErrorTypes.FORBIDDEN);
             expect(res.body).toHaveProperty("errors");
-            expect(res.body.errors).toContainEqual(ValidationReasons.INSUFFICIENT_PERMISSIONS);
+            expect(res.body.errors[0]).toHaveProperty("msg", ValidationReasons.INSUFFICIENT_PERMISSIONS);
         });
 
 
@@ -511,7 +511,7 @@ describe("Company application endpoint", () => {
                 .expect(HTTPStatus.UNAUTHORIZED);
             expect(res.body).toHaveProperty("error_code", ErrorTypes.FORBIDDEN);
             expect(res.body).toHaveProperty("errors");
-            expect(res.body.errors).toContainEqual(ValidationReasons.INSUFFICIENT_PERMISSIONS);
+            expect(res.body.errors[0]).toHaveProperty("msg", ValidationReasons.INSUFFICIENT_PERMISSIONS);
         });
 
         test("should fail if logged in as company", async () => {
@@ -525,7 +525,7 @@ describe("Company application endpoint", () => {
                 .expect(HTTPStatus.UNAUTHORIZED);
             expect(res.body).toHaveProperty("error_code", ErrorTypes.FORBIDDEN);
             expect(res.body).toHaveProperty("errors");
-            expect(res.body.errors).toContainEqual(ValidationReasons.INSUFFICIENT_PERMISSIONS);
+            expect(res.body.errors[0]).toHaveProperty("msg", ValidationReasons.INSUFFICIENT_PERMISSIONS);
         });
 
         test("should allow if logged in as admin", async () => {

--- a/test/end-to-end/offer.js
+++ b/test/end-to-end/offer.js
@@ -90,7 +90,7 @@ describe("Offer endpoint tests", () => {
 
                     expect(res.status).toBe(HTTPStatus.UNAUTHORIZED);
                     expect(res.body).toHaveProperty("errors");
-                    expect(res.body.errors).toContainEqual(ValidationReasons.INSUFFICIENT_PERMISSIONS);
+                    expect(res.body.errors).toContainEqual({ msg: ValidationReasons.INSUFFICIENT_PERMISSIONS });
                 });
 
                 test("should succeed if logged to admin account", async () => {
@@ -144,7 +144,7 @@ describe("Offer endpoint tests", () => {
                     expect(res.status).toBe(HTTPStatus.UNAUTHORIZED);
                     expect(res.body).toHaveProperty("error_code", ErrorTypes.FORBIDDEN);
                     expect(res.body).toHaveProperty("errors");
-                    expect(res.body.errors).toContainEqual(ValidationReasons.INSUFFICIENT_PERMISSIONS);
+                    expect(res.body.errors).toContainEqual({ msg: ValidationReasons.INSUFFICIENT_PERMISSIONS });
                 });
 
                 test("should fail when god token is incorrect", async () => {
@@ -156,7 +156,7 @@ describe("Offer endpoint tests", () => {
 
                     expect(res.status).toBe(HTTPStatus.UNAUTHORIZED);
                     expect(res.body).toHaveProperty("errors");
-                    expect(res.body.errors).toContainEqual(ValidationReasons.INSUFFICIENT_PERMISSIONS);
+                    expect(res.body.errors).toContainEqual({ msg: ValidationReasons.INSUFFICIENT_PERMISSIONS });
                 });
 
                 test("should fail when god token is correct but owner doesn't exist", async () => {
@@ -442,7 +442,7 @@ describe("Offer endpoint tests", () => {
                 expect(res.body).toHaveProperty("error_code", ErrorTypes.VALIDATION_ERROR);
                 expect(res.body).toHaveProperty("errors");
                 expect(res.body.errors).toContainEqual(
-                    ValidationReasons.MAX_CONCURRENT_OFFERS_EXCEEDED(CompanyConstants.offers.max_concurrent));
+                    { msg: ValidationReasons.MAX_CONCURRENT_OFFERS_EXCEEDED(CompanyConstants.offers.max_concurrent) });
             });
 
             test("should fail to create a new offer (with default publishDate)", async () => {
@@ -460,7 +460,7 @@ describe("Offer endpoint tests", () => {
                 expect(res.body).toHaveProperty("error_code", ErrorTypes.VALIDATION_ERROR);
                 expect(res.body).toHaveProperty("errors");
                 expect(res.body.errors).toContainEqual(
-                    ValidationReasons.MAX_CONCURRENT_OFFERS_EXCEEDED(CompanyConstants.offers.max_concurrent));
+                    { msg: ValidationReasons.MAX_CONCURRENT_OFFERS_EXCEEDED(CompanyConstants.offers.max_concurrent) });
             });
         });
 
@@ -504,7 +504,7 @@ describe("Offer endpoint tests", () => {
                 expect(res.body).toHaveProperty("error_code", ErrorTypes.VALIDATION_ERROR);
                 expect(res.body).toHaveProperty("errors");
                 expect(res.body.errors).toContainEqual(
-                    ValidationReasons.MAX_CONCURRENT_OFFERS_EXCEEDED(CompanyConstants.offers.max_concurrent));
+                    { msg: ValidationReasons.MAX_CONCURRENT_OFFERS_EXCEEDED(CompanyConstants.offers.max_concurrent) });
             });
         });
 
@@ -687,7 +687,7 @@ describe("Offer endpoint tests", () => {
                 expect(res.body).toHaveProperty("error_code", ErrorTypes.FORBIDDEN);
                 expect(res.body).toHaveProperty("errors");
                 expect(res.body.errors).toContainEqual(
-                    ValidationReasons.REGISTRATION_NOT_FINISHED);
+                    { msg: ValidationReasons.REGISTRATION_NOT_FINISHED });
             });
         });
 
@@ -1417,7 +1417,7 @@ describe("Offer endpoint tests", () => {
                 expect(res.status).toBe(HTTPStatus.NOT_FOUND);
                 expect(res.body).toHaveProperty("error_code", ErrorTypes.FORBIDDEN);
                 expect(res.body).toHaveProperty("errors");
-                expect(res.body.errors).toContainEqual(ValidationReasons.OFFER_NOT_FOUND(id));
+                expect(res.body.errors).toContainEqual({ msg: ValidationReasons.OFFER_NOT_FOUND(id) });
             });
         });
 
@@ -1653,7 +1653,7 @@ describe("Offer endpoint tests", () => {
             expect(res.status).toBe(HTTPStatus.UNAUTHORIZED);
             expect(res.body).toHaveProperty("error_code", ErrorTypes.FORBIDDEN);
             expect(res.body).toHaveProperty("errors");
-            expect(res.body.errors).toContainEqual(ValidationReasons.INSUFFICIENT_PERMISSIONS);
+            expect(res.body.errors).toContainEqual({ msg: ValidationReasons.INSUFFICIENT_PERMISSIONS });
         });
 
         describe("testing validations with god token", () => {
@@ -1683,7 +1683,7 @@ describe("Offer endpoint tests", () => {
                     .send(withGodToken())
                     .expect(HTTPStatus.FORBIDDEN);
                 expect(res.body).toHaveProperty("errors");
-                expect(res.body.errors).toContainEqual(ValidationReasons.OFFER_EXPIRED(expired_test_offer._id.toString()));
+                expect(res.body.errors).toContainEqual({ msg: ValidationReasons.OFFER_EXPIRED(expired_test_offer._id.toString()) });
             });
 
             describe("should fail if offer with grace period over", () => {
@@ -1705,7 +1705,9 @@ describe("Offer endpoint tests", () => {
                         .send(withGodToken())
                         .expect(HTTPStatus.FORBIDDEN);
                     expect(res.body).toHaveProperty("errors");
-                    expect(res.body.errors).toContainEqual(ValidationReasons.OFFER_EDIT_PERIOD_OVER(expired_over_hours.toFixed(2)));
+                    expect(res.body.errors).toContainEqual({
+                        msg: ValidationReasons.OFFER_EDIT_PERIOD_OVER(expired_over_hours.toFixed(2))
+                    });
                 });
 
             });
@@ -1840,7 +1842,7 @@ describe("Offer endpoint tests", () => {
                         .expect(HTTPStatus.FORBIDDEN);
                     expect(res.body).toHaveProperty("error_code", ErrorTypes.FORBIDDEN);
                     expect(res.body).toHaveProperty("errors");
-                    expect(res.body.errors).toContainEqual(ValidationReasons.OFFER_BLOCKED_ADMIN);
+                    expect(res.body.errors).toContainEqual({ msg: ValidationReasons.OFFER_BLOCKED_ADMIN });
                 });
 
                 test("should fail if minDuration bigger than offer's maxDuration", async () => {
@@ -1995,7 +1997,7 @@ describe("Offer endpoint tests", () => {
                         .expect(HTTPStatus.FORBIDDEN);
                     expect(res.body).toHaveProperty("or");
                     expect(res.body.or[0]).toHaveProperty("errors");
-                    expect(res.body.or[0].errors).toContainEqual(ValidationReasons.NOT_OFFER_OWNER(future_test_offer._id));
+                    expect(res.body.or[0].errors).toContainEqual({ msg: ValidationReasons.NOT_OFFER_OWNER(future_test_offer._id) });
                 });
 
             });
@@ -2163,7 +2165,7 @@ describe("Offer endpoint tests", () => {
             expect(res.status).toBe(HTTPStatus.UNAUTHORIZED);
             expect(res.body).toHaveProperty("error_code", ErrorTypes.FORBIDDEN);
             expect(res.body).toHaveProperty("errors");
-            expect(res.body.errors).toContainEqual(ValidationReasons.INSUFFICIENT_PERMISSIONS);
+            expect(res.body.errors).toContainEqual({ msg: ValidationReasons.INSUFFICIENT_PERMISSIONS });
         });
 
         test("should fail to disable offer if logged in as company", async () => {
@@ -2180,7 +2182,7 @@ describe("Offer endpoint tests", () => {
             expect(res.status).toBe(HTTPStatus.UNAUTHORIZED);
             expect(res.body).toHaveProperty("error_code", ErrorTypes.FORBIDDEN);
             expect(res.body).toHaveProperty("errors");
-            expect(res.body.errors).toContainEqual(ValidationReasons.INSUFFICIENT_PERMISSIONS);
+            expect(res.body.errors).toContainEqual({ msg: ValidationReasons.INSUFFICIENT_PERMISSIONS });
         });
 
         test("should allow disabing offer if logged in as god", async () => {
@@ -2219,7 +2221,7 @@ describe("Offer endpoint tests", () => {
                 .expect(HTTPStatus.FORBIDDEN);
             expect(res.body).toHaveProperty("error_code", ErrorTypes.FORBIDDEN);
             expect(res.body).toHaveProperty("errors");
-            expect(res.body.errors).toContainEqual(ValidationReasons.OFFER_HIDDEN);
+            expect(res.body.errors).toContainEqual({ msg: ValidationReasons.OFFER_HIDDEN });
         });
 
         test("should allow disabling if offer hidden by default", async () => {
@@ -2338,7 +2340,7 @@ describe("Offer endpoint tests", () => {
             expect(res.status).toBe(HTTPStatus.UNAUTHORIZED);
             expect(res.body).toHaveProperty("error_code", ErrorTypes.FORBIDDEN);
             expect(res.body).toHaveProperty("errors");
-            expect(res.body.errors).toContainEqual(ValidationReasons.INSUFFICIENT_PERMISSIONS);
+            expect(res.body.errors).toContainEqual({ msg: ValidationReasons.INSUFFICIENT_PERMISSIONS });
         });
 
         test("should hide successfully if admin", async () => {
@@ -2365,7 +2367,7 @@ describe("Offer endpoint tests", () => {
                 .expect(HTTPStatus.FORBIDDEN);
             expect(res.body).toHaveProperty("or");
             expect(res.body.or[0]).toHaveProperty("errors");
-            expect(res.body.or[0].errors).toContainEqual(ValidationReasons.NOT_OFFER_OWNER(test_offer_2._id));
+            expect(res.body.or[0].errors).toContainEqual({ msg: ValidationReasons.NOT_OFFER_OWNER(test_offer_2._id) });
         });
 
         test("should hide successfully if logged in as the owner company", async () => {
@@ -2387,7 +2389,7 @@ describe("Offer endpoint tests", () => {
                 .expect(HTTPStatus.FORBIDDEN);
             expect(res.body).toHaveProperty("error_code", ErrorTypes.FORBIDDEN);
             expect(res.body).toHaveProperty("errors");
-            expect(res.body.errors).toContainEqual(ValidationReasons.OFFER_HIDDEN);
+            expect(res.body.errors).toContainEqual({ msg: ValidationReasons.OFFER_HIDDEN });
         });
 
         test("should fail if already hidden offer by user", async () => {
@@ -2396,7 +2398,7 @@ describe("Offer endpoint tests", () => {
                 .expect(HTTPStatus.FORBIDDEN);
             expect(res.body).toHaveProperty("error_code", ErrorTypes.FORBIDDEN);
             expect(res.body).toHaveProperty("errors");
-            expect(res.body.errors).toContainEqual(ValidationReasons.OFFER_HIDDEN);
+            expect(res.body.errors).toContainEqual({ msg: ValidationReasons.OFFER_HIDDEN });
         });
 
         test("should fail to hide if already disabled by admin", async () => {
@@ -2405,7 +2407,7 @@ describe("Offer endpoint tests", () => {
                 .expect(HTTPStatus.FORBIDDEN);
             expect(res.body).toHaveProperty("error_code", ErrorTypes.FORBIDDEN);
             expect(res.body).toHaveProperty("errors");
-            expect(res.body.errors).toContainEqual(ValidationReasons.OFFER_HIDDEN);
+            expect(res.body.errors).toContainEqual({ msg: ValidationReasons.OFFER_HIDDEN });
         });
     });
 
@@ -2469,7 +2471,7 @@ describe("Offer endpoint tests", () => {
             expect(res.status).toBe(HTTPStatus.UNAUTHORIZED);
             expect(res.body).toHaveProperty("error_code", ErrorTypes.FORBIDDEN);
             expect(res.body).toHaveProperty("errors");
-            expect(res.body.errors).toContainEqual(ValidationReasons.INSUFFICIENT_PERMISSIONS);
+            expect(res.body.errors).toContainEqual({ msg: ValidationReasons.INSUFFICIENT_PERMISSIONS });
         });
 
         test("should enable successfully if admin and offer hidden by default as an admin", async () => {
@@ -2507,7 +2509,7 @@ describe("Offer endpoint tests", () => {
                 .expect(HTTPStatus.FORBIDDEN);
             expect(res.body).toHaveProperty("error_code", ErrorTypes.FORBIDDEN);
             expect(res.body).toHaveProperty("errors");
-            expect(res.body.errors).toContainEqual(ValidationReasons.OFFER_BLOCKED_ADMIN);
+            expect(res.body.errors).toContainEqual({ msg: ValidationReasons.OFFER_BLOCKED_ADMIN });
         });
 
         describe("testing concurrent offers", () => {
@@ -2543,7 +2545,7 @@ describe("Offer endpoint tests", () => {
                 expect(res.body).toHaveProperty("error_code", ErrorTypes.VALIDATION_ERROR);
                 expect(res.body).toHaveProperty("errors");
                 expect(res.body.errors)
-                    .toContainEqual(ValidationReasons.MAX_CONCURRENT_OFFERS_EXCEEDED(CompanyConstants.offers.max_concurrent));
+                    .toContainEqual({ msg: ValidationReasons.MAX_CONCURRENT_OFFERS_EXCEEDED(CompanyConstants.offers.max_concurrent) });
             });
         });
 

--- a/test/end-to-end/offer.js
+++ b/test/end-to-end/offer.js
@@ -715,8 +715,7 @@ describe("Offer endpoint tests", () => {
                 expect(res.status).toBe(HTTPStatus.FORBIDDEN);
                 expect(res.body).toHaveProperty("error_code", ErrorTypes.FORBIDDEN);
                 expect(res.body).toHaveProperty("errors");
-                expect(res.body.errors).toContainEqual(
-                    ValidationReasons.COMPANY_BLOCKED);
+                expect(res.body.errors[0]).toHaveProperty("msg", ValidationReasons.COMPANY_BLOCKED);
             });
 
         });

--- a/test/end-to-end/review.js
+++ b/test/end-to-end/review.js
@@ -361,7 +361,7 @@ describe("Company application review endpoint test", () => {
 
                         expect(res.status).toBe(HTTPStatus.CONFLICT);
                         expect(res.body.error_code).toBe(ErrorTypes.VALIDATION_ERROR);
-                        expect(res.body.errors[0]).toBe(CompanyApplicationRules.EMAIL_ALREADY_IN_USE.msg);
+                        expect(res.body.errors[0].msg).toBe(CompanyApplicationRules.EMAIL_ALREADY_IN_USE.msg);
 
                         const result_application = await CompanyApplication.findById(application._id);
                         expect(result_application.state).toBe(ApplicationStatus.PENDING);

--- a/test/unit/utils.js
+++ b/test/unit/utils.js
@@ -59,17 +59,17 @@ describe("Middleware utils", () => {
                 or: [
                     {
                         error_code: 1,
-                        errors: ["error_message1"],
+                        errors: [{ msg: "error_message1" }],
                         test: 1
                     },
                     {
                         error_code: 2,
-                        errors: ["error_message2"],
+                        errors: [{ msg: "error_message2" }],
                         test: 2
                     },
                     {
                         error_code: 3,
-                        errors: ["error_message3"],
+                        errors: [{ msg: "error_message3" }],
                         test: 3
                     },
                 ]
@@ -96,17 +96,17 @@ describe("Middleware utils", () => {
                 or: [
                     {
                         error_code: 1,
-                        errors: ["error_message1"],
+                        errors: [{ msg: "error_message1" }],
                         test: 1
                     },
                     {
                         error_code: 2,
-                        errors: ["error_message2"],
+                        errors: [{ msg: "error_message2" }],
                         test: 2
                     },
                     {
                         error_code: 3,
-                        errors: ["error_message3"],
+                        errors: [{ msg: "error_message3" }],
                         test: 3
                     },
                 ]


### PR DESCRIPTION
closes #109 

I changed the way the APIError handles its arguments since different functions are passing a simple error message or an array of errors to it. I also checked all the api code to look for errors without the intended format but let me know if I missed something.

Also, I wasn't sure but I changed some errors which were being thrown in custom validators (offer and application) to APIErrors, for consistency, even though they are going to be wrapped with the useExpressValidators function. I didn't do this in validatorUtils because they are not used in a specific endpoint. Let me know if you want me to revert them all to throw normal errors again