### PR TITLE
Fix/ wrong offer query

### DIFF
--- a/src/services/offer.js
+++ b/src/services/offer.js
@@ -195,7 +195,7 @@ class OfferService {
             .limit(limit)
         ;
 
-        return showAdminReason ? offersQuery : offers.select("-adminReason");
+        return showAdminReason ? offersQuery : offersQuery.select("-adminReason");
 
     }
     _buildFilterQuery(filters) {


### PR DESCRIPTION
As of #154, the query used in the get method of the Offer service was the wrong one. This PR corrects that. 