### PR TITLE
Fix emails not being sent because of wrong path

### DIFF
--- a/src/lib/emailService.js
+++ b/src/lib/emailService.js
@@ -20,13 +20,13 @@ export class EmailService {
 
         transporter.use("compile", hbs({
             viewEngine: {
-                layoutsDir: `${path.resolve()}/../email-templates/layouts`,
-                partialsDir: `${path.resolve()}/../email-templates/partials/`,
+                layoutsDir: `${path.resolve()}/src/email-templates/layouts`,
+                partialsDir: `${path.resolve()}/src/email-templates/partials/`,
                 extName: ".handlebars",
                 defaultLayout: "main"
             },
             extName: ".handlebars",
-            viewPath: `${path.resolve()}/../email-templates/`,
+            viewPath: `${path.resolve()}/src/email-templates/`,
         }));
 
         this.transporter = transporter;


### PR DESCRIPTION
In tests, sendMail is being mocked, so path.resolve() was actually not being tested, hence the test would not crash