### PR TITLE
Fix/hide hidden offers

### DIFF
--- a/src/api/middleware/offer.js
+++ b/src/api/middleware/offer.js
@@ -19,7 +19,8 @@ export const isOwnerNotBlocked = async (req, res, next) => {
 };
 
 export const setTargetOwner = (req, res, next) => {
+    const wantedTargetOwner = req.hasAdminPrivileges && req.body.owner;
+    req.targetOwner = req.user?.company?._id.toString() || wantedTargetOwner || undefined;
 
-    req.targetOwner = req.user?.company?._id.toString() || req.body.owner;
     return next();
 };

--- a/src/api/middleware/offer.js
+++ b/src/api/middleware/offer.js
@@ -19,7 +19,7 @@ export const isOwnerNotBlocked = async (req, res, next) => {
 };
 
 export const setTargetOwner = (req, res, next) => {
-    const wantedTargetOwner = req.hasAdminPrivileges && req.body.owner;
+    const adminTargetOwner = req.hasAdminPrivileges && req.body.owner;
     req.targetOwner = req.user?.company?._id.toString() || wantedTargetOwner || undefined;
 
     return next();

--- a/src/api/middleware/offer.js
+++ b/src/api/middleware/offer.js
@@ -20,7 +20,7 @@ export const isOwnerNotBlocked = async (req, res, next) => {
 
 export const setTargetOwner = (req, res, next) => {
     const adminTargetOwner = req.hasAdminPrivileges && req.body.owner;
-    req.targetOwner = req.user?.company?._id.toString() || wantedTargetOwner || undefined;
+    req.targetOwner = req.user?.company?._id.toString() || adminTargetOwner || undefined;
 
     return next();
 };


### PR DESCRIPTION
Closes #250.

These changes introduce a check to make it so that the target owner in any request can only be set if the user has admin privileges. As such, regular users will be unable to see hidden offers.