### PR TITLE
247 default order offers by most recent

### DIFF
--- a/src/api/middleware/validators/offer.js
+++ b/src/api/middleware/validators/offer.js
@@ -444,9 +444,17 @@ export const setDefaultValuesCreate = (req, res, next) => {
 
 const validGetQueryToken = async (queryToken, { req }) => {
     try {
-        const { id, score, value } = (new OfferService()).decodeQueryToken(queryToken);
+        const { id, publishDate, score, value } = (new OfferService()).decodeQueryToken(queryToken);
         if (!isObjectId(id)) throw new Error(ValidationReasons.OBJECT_ID);
         await existingOfferId(id, { req });
+
+        if (typeof publishDate === "undefined") {
+            throw new Error(ValidationReasons.REQUIRED);
+        } else {
+            if (typeof publishDate !== Date) {
+                throw new Error(ValidationReasons.DATE);
+            }
+        }
 
         if (value) {
             if (isNaN(score)) throw new Error(ValidationReasons.NUMBER);

--- a/src/api/middleware/validators/offer.js
+++ b/src/api/middleware/validators/offer.js
@@ -444,16 +444,16 @@ export const setDefaultValuesCreate = (req, res, next) => {
 
 const validGetQueryToken = async (queryToken, { req }) => {
     try {
-        const { id, publishDate, score, value } = (new OfferService()).decodeQueryToken(queryToken);
+        const { id, score, publishDate, value } = (new OfferService()).decodeQueryToken(queryToken);
         if (!isObjectId(id)) throw new Error(ValidationReasons.OBJECT_ID);
         await existingOfferId(id, { req });
 
         if (typeof publishDate === "undefined") {
             throw new Error(ValidationReasons.REQUIRED);
-        } else {
-            if (typeof publishDate !== Date) {
-                throw new Error(ValidationReasons.DATE);
-            }
+        }
+
+        if (!(publishDate instanceof Date)) {
+            throw new Error(ValidationReasons.DATE);
         }
 
         if (value) {

--- a/src/services/offer.js
+++ b/src/services/offer.js
@@ -230,7 +230,8 @@ class OfferService {
         const results = await offers
             .sort(queryValue ? { score: { "$meta": "textScore" }, _id: 1 } : { _id: 1 })
             .limit(limit)
-        ;
+            .sort({ publishDate: -1 })
+            ;
 
         if (results.length > 0) {
             const lastOffer = results[results.length - 1];

--- a/src/services/offer.js
+++ b/src/services/offer.js
@@ -228,8 +228,6 @@ class OfferService {
         }
 
         const results = await offers
-            .select("-publishEndDate -jobStartDate -description -contacts -jobType -fields -isHidden -isArchived -owner -requirements \
-            -ownerName -ownerLogo -location -createdAt -updatedAt -__v")
             .sort({
                 ...(queryValue ? { score: { "$meta": "textScore" } } : {}),
                 publishDate: -1,

--- a/src/services/offer.js
+++ b/src/services/offer.js
@@ -228,10 +228,14 @@ class OfferService {
         }
 
         const results = await offers
-            .sort(queryValue ? { score: { "$meta": "textScore" }, _id: 1 } : { _id: 1 })
-            .limit(limit)
-            .sort({ publishDate: -1 })
-            ;
+            .select("-publishEndDate -jobStartDate -description -contacts -jobType -fields -isHidden -isArchived -owner -requirements \
+            -ownerName -ownerLogo -location -createdAt -updatedAt -__v")
+            .sort({
+                ...(queryValue ? { score: { "$meta": "textScore" } } : {}),
+                publishDate: -1,
+                _id: 1,
+            })
+            .limit(limit);
 
         if (results.length > 0) {
             const lastOffer = results[results.length - 1];

--- a/test/end-to-end/offer.js
+++ b/test/end-to-end/offer.js
@@ -1517,10 +1517,8 @@ describe("Offer endpoint tests", () => {
                                     expect(res.body.results[i].publishDate)
                                         .toBe(res.body.results[i + 1].publishDate);
 
-                                    // eslint-disable-next-line no-undef
-                                    expect(BigInt(`0x${res.body.results[i]._id}`))
-                                        // eslint-disable-next-line no-undef
-                                        .toBeLessThan(BigInt(`0x${res.body.results[i + 1]._id}`));
+                                    expect(res.body.results[i]._id < res.body.results[i + 1]._id)
+                                        .toBeTruthy();
                                 }
                             }
                         });
@@ -1567,10 +1565,8 @@ describe("Offer endpoint tests", () => {
 
                             expect(res2.status).toBe(HTTPStatus.OK);
                             expect(res2.body.results).toHaveLength(1);
-                            // eslint-disable-next-line no-undef
-                            expect(BigInt(`0x${res2.body.results[0]._id}`))
-                                // eslint-disable-next-line no-undef
-                                .toBeGreaterThan(BigInt(`0x${res1.body.results[1]._id}`));
+                            expect(res2.body.results[0]._id > res1.body.results[1]._id)
+                                .toBeTruthy();
                         });
                     });
                 });
@@ -2176,10 +2172,8 @@ describe("Offer endpoint tests", () => {
                                         expect(res.body.results[i].publishDate)
                                             .toBe(res.body.results[i + 1].publishDate);
 
-                                        // eslint-disable-next-line no-undef
-                                        expect(BigInt(`0x${res.body.results[i]._id}`))
-                                            // eslint-disable-next-line no-undef
-                                            .toBeLessThan(BigInt(`0x${res.body.results[i + 1]._id}`));
+                                        expect(res.body.results[i]._id < res.body.results[i + 1]._id)
+                                            .toBeTruthy();
                                     }
                                 }
                             }
@@ -2255,10 +2249,8 @@ describe("Offer endpoint tests", () => {
                             expect(res2.status).toBe(HTTPStatus.OK);
                             expect(res2.body.results).toHaveLength(1);
 
-                            // eslint-disable-next-line no-undef
-                            expect(BigInt(`0x${res2.body.results[0]._id}`))
-                                // eslint-disable-next-line no-undef
-                                .toBeGreaterThan(BigInt(`0x${res1.body.results[3]._id}`));
+                            expect(res2.body.results[0]._id > res1.body.results[3]._id)
+                                .toBeTruthy();
                         });
 
                         test("Should succeed if there are no more offers after the last one", async () => {

--- a/test/end-to-end/offer.js
+++ b/test/end-to-end/offer.js
@@ -1069,7 +1069,7 @@ describe("Offer endpoint tests", () => {
 
             describe("queryToken validation", () => {
                 test("should fail if queryToken does not contain a valid id", async () => {
-                    const queryToken = (new OfferService()).encodeQueryToken("123");
+                    const queryToken = (new OfferService()).encodeQueryToken("123", 10, mockCurrentDate, "test");
 
                     const res = await request()
                         .get("/offers")
@@ -1084,7 +1084,7 @@ describe("Offer endpoint tests", () => {
                 });
 
                 test("should fail if the queryToken's offer does not exist", async () => {
-                    const queryToken = (new OfferService()).encodeQueryToken("5facf0cdb8bc30016ee58952");
+                    const queryToken = (new OfferService()).encodeQueryToken("5facf0cdb8bc30016ee58952", 10, mockCurrentDate, "test");
                     const res = await request()
                         .get("/offers")
                         .query({ queryToken });
@@ -1100,7 +1100,7 @@ describe("Offer endpoint tests", () => {
                 test("should fail if the queryToken's score is not a number", async () => {
                     const testOfferId = (await Offer.findOne({}))._id;
                     const queryToken = (new OfferService())
-                        .encodeQueryToken(testOfferId, "hello", "test");
+                        .encodeQueryToken(testOfferId, "hello", mockCurrentDate, "test");
 
                     const res = await request()
                         .get("/offers")
@@ -1117,7 +1117,7 @@ describe("Offer endpoint tests", () => {
                 test("should fail if the queryToken's score is negative", async () => {
                     const testOfferId = (await Offer.findOne({}))._id;
                     const queryToken = (new OfferService())
-                        .encodeQueryToken(testOfferId, -5, "test");
+                        .encodeQueryToken(testOfferId, -5, mockCurrentDate, "test");
 
                     const res = await request()
                         .get("/offers")
@@ -1134,7 +1134,7 @@ describe("Offer endpoint tests", () => {
                 test("should fail if the queryToken's value is present and score is missing", async () => {
                     const testOfferId = (await Offer.findOne({}))._id;
                     const queryToken = (new OfferService())
-                        .encodeQueryToken(testOfferId, undefined, "test");
+                        .encodeQueryToken(testOfferId, undefined, mockCurrentDate, "test");
 
                     const res = await request()
                         .get("/offers")
@@ -1151,7 +1151,7 @@ describe("Offer endpoint tests", () => {
                 test("should fail if the queryToken's score is present and value is missing", async () => {
                     const testOfferId = (await Offer.findOne({}))._id;
                     const queryToken = (new OfferService())
-                        .encodeQueryToken(testOfferId, 5);
+                        .encodeQueryToken(testOfferId, 5, mockCurrentDate);
 
                     const res = await request()
                         .get("/offers")
@@ -1168,7 +1168,7 @@ describe("Offer endpoint tests", () => {
                 test("should succeed when the queryToken's value and score are missing", async () => {
                     const testOfferId = (await Offer.findOne({}))._id;
                     const queryToken = (new OfferService())
-                        .encodeQueryToken(testOfferId);
+                        .encodeQueryToken(testOfferId, undefined, mockCurrentDate, undefined);
 
                     const res = await request()
                         .get("/offers")
@@ -1180,7 +1180,7 @@ describe("Offer endpoint tests", () => {
                 test("should succeed when the queryToken's value is present and score is a valid number", async () => {
                     const testOfferId = (await Offer.findOne({}))._id;
                     const queryToken = (new OfferService())
-                        .encodeQueryToken(testOfferId, 5, "test");
+                        .encodeQueryToken(testOfferId, 5, mockCurrentDate, "test");
 
                     const res = await request()
                         .get("/offers")
@@ -1192,7 +1192,7 @@ describe("Offer endpoint tests", () => {
                 test("should succeed when value is present and queryToken's score can be parsed as a number", async () => {
                     const testOfferId = (await Offer.findOne({}))._id;
                     const queryToken = (new OfferService())
-                        .encodeQueryToken(testOfferId, "3.5", "test");
+                        .encodeQueryToken(testOfferId, "3.5", mockCurrentDate, "test");
 
                     const res = await request()
                         .get("/offers")


### PR DESCRIPTION
Closes #247 

Offers are now ordered with the following precedence: score > publish date (by most recent) > id. I ran the test below using Postman to check if it was working as intended (using the query "Julia"):

![orderPublishDateTest](https://user-images.githubusercontent.com/96185733/205948309-df037284-c411-40ca-9cb9-f983f4dab9bc.png)
