### PR TITLE
Add *past date* validation to `publishDate` in offer creation

### DIFF
--- a/src/api/middleware/validators/offer.js
+++ b/src/api/middleware/validators/offer.js
@@ -79,6 +79,7 @@ export const create = useExpressValidators([
     body("publishDate", ValidationReasons.DEFAULT)
         .optional()
         .isISO8601({ strict: true }).withMessage(ValidationReasons.DATE).bail()
+        .isAfter().withMessage(ValidationReasons.DATE_EXPIRED).bail()
         .customSanitizer(normalizeDate),
 
     body("publishEndDate", ValidationReasons.DEFAULT)

--- a/test/end-to-end/company.js
+++ b/test/end-to-end/company.js
@@ -34,7 +34,7 @@ describe("Company endpoint", () => {
 
     const generateTestOffer = (params) => ({
         title: "Test Offer",
-        publishDate: (new Date(Date.now() - (DAY_TO_MS))).toISOString(),
+        publishDate: (new Date()).toISOString(),
         publishEndDate: (new Date(Date.now() + (DAY_TO_MS))).toISOString(),
         description: "For Testing Purposes",
         contacts: ["geral@niaefeup.pt", "229417766"],
@@ -646,7 +646,7 @@ describe("Company endpoint", () => {
 
                 const offers = Array(3).fill(await Offer.create({
                     ...generateTestOffer({
-                        "publishDate": (new Date(Date.now() - (DAY_TO_MS))).toISOString(),
+                        "publishDate": (new Date(Date.now())).toISOString(),
                         "publishEndDate": (new Date(Date.now() + (DAY_TO_MS))).toISOString()
                     }),
                     owner: test_company._id,
@@ -674,7 +674,7 @@ describe("Company endpoint", () => {
 
                 const offer = await Offer.create({
                     ...generateTestOffer({
-                        "publishDate": (new Date(Date.now() - (DAY_TO_MS))).toISOString(),
+                        "publishDate": (new Date(Date.now())).toISOString(),
                         "publishEndDate": (new Date(Date.now() + (DAY_TO_MS))).toISOString()
                     }),
                     owner: test_company._id,
@@ -887,7 +887,7 @@ describe("Company endpoint", () => {
 
                 const offers = Array(3).fill(await Offer.create({
                     ...generateTestOffer({
-                        "publishDate": (new Date(Date.now() - (DAY_TO_MS))).toISOString(),
+                        "publishDate": (new Date(Date.now())).toISOString(),
                         "publishEndDate": (new Date(Date.now() + (DAY_TO_MS))).toISOString()
                     }),
                     owner: test_company._id,
@@ -912,7 +912,7 @@ describe("Company endpoint", () => {
 
                 const offer = await Offer.create({
                     ...generateTestOffer({
-                        "publishDate": (new Date(Date.now() - (DAY_TO_MS))).toISOString(),
+                        "publishDate": (new Date(Date.now())).toISOString(),
                         "publishEndDate": (new Date(Date.now() + (DAY_TO_MS))).toISOString()
                     }),
                     owner: test_company._id,
@@ -939,7 +939,7 @@ describe("Company endpoint", () => {
 
                 const offer = await Offer.create({
                     ...generateTestOffer({
-                        "publishDate": (new Date(Date.now() - (DAY_TO_MS))).toISOString(),
+                        "publishDate": (new Date(Date.now())).toISOString(),
                         "publishEndDate": (new Date(Date.now() + (DAY_TO_MS))).toISOString()
                     }),
                     owner: test_company._id,
@@ -1069,7 +1069,7 @@ describe("Company endpoint", () => {
 
             const offer = {
                 title: "Test Offer",
-                publishDate: new Date(Date.now() - (DAY_TO_MS)),
+                publishDate: new Date(Date.now()),
                 publishEndDate: new Date(Date.now() + (DAY_TO_MS)),
                 description: "For Testing Purposes",
                 contacts: ["geral@niaefeup.pt", "229417766"],
@@ -1314,7 +1314,7 @@ describe("Company endpoint", () => {
 
             const offer = {
                 title: "Test Offer",
-                publishDate: new Date(Date.now() - (DAY_TO_MS)),
+                publishDate: new Date(Date.now()),
                 publishEndDate: new Date(Date.now() + (DAY_TO_MS)),
                 description: "For Testing Purposes",
                 contacts: ["geral@niaefeup.pt", "229417766"],
@@ -1683,7 +1683,7 @@ describe("Company endpoint", () => {
 
         const test_agent = agent();
 
-        const publishDate = (new Date(Date.now() - (2 * DAY_TO_MS))).toISOString();
+        const publishDate = (new Date(Date.now())).toISOString();
         const publishEndDate = (new Date(Date.now() + (2 * DAY_TO_MS))).toISOString();
 
         beforeEach(async () => {
@@ -1726,7 +1726,7 @@ describe("Company endpoint", () => {
                     owner: test_company_2._id,
                     ownerName: test_company_2.name,
                     ownerLogo: test_company_2.logo,
-                    "publishDate": (new Date(Date.now() - (DAY_TO_MS))).toISOString(),
+                    "publishDate": (new Date(Date.now())).toISOString(),
                     "publishEndDate": (new Date(Date.now() + (DAY_TO_MS))).toISOString()
                 }));
 

--- a/test/end-to-end/offer.js
+++ b/test/end-to-end/offer.js
@@ -26,7 +26,7 @@ import { OFFER_DISABLED_NOTIFICATION } from "../../src/email-templates/companyOf
 describe("Offer endpoint tests", () => {
     const generateTestOffer = (params) => ({
         title: "Test Offer",
-        publishDate: (new Date(Date.now() - (DAY_TO_MS))).toISOString(),
+        publishDate: (new Date(Date.now())).toISOString(),
         publishEndDate: (new Date(Date.now() + (DAY_TO_MS))).toISOString(),
         description: "For Testing Purposes",
         contacts: ["geral@niaefeup.pt", "229417766"],
@@ -218,6 +218,7 @@ describe("Offer endpoint tests", () => {
             describe("publishDate", () => {
                 const FieldValidatorTester = BodyValidatorTester("publishDate");
                 FieldValidatorTester.mustBeDate();
+                FieldValidatorTester.mustBeFuture();
             });
 
             describe("publishEndDate", () => {
@@ -320,7 +321,7 @@ describe("Offer endpoint tests", () => {
 
             test("Should fail to create an offer due to publish end date being after publish date more than the limit", async () => {
                 const offer = generateTestOffer();
-                const publishDate = new Date(Date.now() - (DAY_TO_MS));
+                const publishDate = new Date(Date.now());
                 const offer_params = {
                     ...offer,
                     owner: test_company._id,
@@ -439,7 +440,7 @@ describe("Offer endpoint tests", () => {
         describe("Before reaching the offers limit while having past offers", () => {
             const testOffers = Array(CompanyConstants.offers.max_concurrent - 1)
                 .fill(generateTestOffer({
-                    "publishDate": (new Date(Date.now() - (DAY_TO_MS))).toISOString(),
+                    "publishDate": (new Date(Date.now())).toISOString(),
                     "publishEndDate": (new Date(Date.now() + (DAY_TO_MS))).toISOString()
                 }));
 
@@ -486,7 +487,7 @@ describe("Offer endpoint tests", () => {
         describe("After reaching the offers limit", () => {
             const testOffers = Array(CompanyConstants.offers.max_concurrent)
                 .fill(generateTestOffer({
-                    "publishDate": (new Date(Date.now() - (DAY_TO_MS))).toISOString(),
+                    "publishDate": (new Date(Date.now())).toISOString(),
                     "publishEndDate": (new Date(Date.now() + (DAY_TO_MS))).toISOString()
                 }));
 
@@ -4486,7 +4487,7 @@ describe("Offer endpoint tests", () => {
                             owner: test_company._id.toString(),
                             ownerName: test_company.name,
                             ownerLogo: test_company.logo,
-                            publishDate: (new Date(now - (DAY_TO_MS))).toISOString(),
+                            publishDate: (new Date(now)).toISOString(),
                             publishEndDate: (new Date(now + (DAY_TO_MS))).toISOString()
                         }));
                 }
@@ -4496,7 +4497,7 @@ describe("Offer endpoint tests", () => {
                         owner: test_company._id.toString(),
                         ownerName: test_company.name,
                         ownerLogo: test_company.logo,
-                        publishDate: (new Date(now - (DAY_TO_MS))).toISOString(),
+                        publishDate: (new Date(now)).toISOString(),
                         publishEndDate: (new Date(now + (DAY_TO_MS))).toISOString()
                     }));
 


### PR DESCRIPTION
Closes #261

I should mention that the offers in the offer and company tests had outdated dates. This should be considered in the test refactor, as there may exist more invalid dates in other files that didn't fail tests.